### PR TITLE
feat: explicit stale/semantic alerting in monitors

### DIFF
--- a/.github/workflows/monitor-production.yml
+++ b/.github/workflows/monitor-production.yml
@@ -31,4 +31,5 @@ jobs:
           COASENSUS_BASE_URL: "https://coasensus.com"
           COASENSUS_ADMIN_TOKEN: ${{ secrets.COASENSUS_ADMIN_REFRESH_TOKEN_PROD }}
           COASENSUS_MAX_STALE_MINUTES: "90"
+          COASENSUS_SEMANTIC_FAILURE_STREAK: "3"
         run: node scripts/monitor-production.mjs

--- a/.github/workflows/monitor-staging.yml
+++ b/.github/workflows/monitor-staging.yml
@@ -31,4 +31,5 @@ jobs:
           COASENSUS_BASE_URL: "https://staging.coasensus.com"
           COASENSUS_ADMIN_TOKEN: ${{ secrets.COASENSUS_ADMIN_REFRESH_TOKEN_STAGING }}
           COASENSUS_MAX_STALE_MINUTES: "90"
+          COASENSUS_SEMANTIC_FAILURE_STREAK: "3"
         run: node scripts/monitor-production.mjs

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -287,6 +287,18 @@ This file is the explicit handoff checkpoint.
    - staging monitor `22252905034` success.
 59. Next recommended milestone:
    - implement `MILESTONE-ALERT-005` (alerting for stale feed / repeated semantic failures).
+60. Alert milestone implementation (`MILESTONE-ALERT-005`) completed on `agent/alerting-pass1`:
+   - monitor script now emits explicit alert-coded failures:
+     - `[ALERT_EMPTY_FEED]` when feed returns zero items
+     - `[ALERT_STALE_FEED]` when latest telemetry age exceeds threshold
+     - `[ALERT_SEMANTIC_FAILURE_STREAK]` when `llmFailures > 0` across configured consecutive runs
+   - added `COASENSUS_SEMANTIC_FAILURE_STREAK` env var (default `3`) and dynamic telemetry window fetch.
+61. Monitor workflow updates:
+   - `.github/workflows/monitor-production.yml` and `.github/workflows/monitor-staging.yml` now set:
+     - `COASENSUS_SEMANTIC_FAILURE_STREAK=3`
+   - existing stale threshold remains `COASENSUS_MAX_STALE_MINUTES=90`.
+62. Next recommended milestone:
+   - implement `MILESTONE-RATE-006` (per-session rate-limited analytics sampling).
 
 ## How to start a fresh Codex session
 1. Open terminal in repo: `E:\Coasensus Predictive future`

--- a/docs/ISSUE_CHECKLIST.md
+++ b/docs/ISSUE_CHECKLIST.md
@@ -43,6 +43,7 @@
 - [x] `QA-003` Add API smoke tests
 - [x] `QA-004` Add deploy verification checklist
 - [x] `QA-005` Define launch gate criteria
+- [x] `QA-006` Add explicit monitor alerts for stale feed and semantic failure streaks
 
 ## EPIC-06 Hybrid Semantic Layer (Execution Plan V2)
 - [x] `SEM-001` Add phase-1 bouncer prefilter (query + local gates)

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -503,3 +503,17 @@
 182. Post-rollout monitors for trend milestone:
    - production monitor `22252904455` => success (`totalItems=86`, `llmFailures=0`, runId `2026-02-21T07-30-28-219Z`)
    - staging monitor `22252905034` => success (`totalItems=85`, `llmFailures=0`, runId `2026-02-21T07-30-27-972Z`).
+183. Started `MILESTONE-ALERT-005` on branch `agent/alerting-pass1`.
+184. Upgraded monitor alerting logic in `scripts/monitor-production.mjs`:
+   - added explicit alert codes in failure messages:
+     - `[ALERT_EMPTY_FEED]`
+     - `[ALERT_STALE_FEED]`
+     - `[ALERT_SEMANTIC_FAILURE_STREAK]`
+   - added configurable `COASENSUS_SEMANTIC_FAILURE_STREAK` (default `3`), and telemetry query now fetches a matching run window.
+   - semantic streak alert triggers when latest N runs all have `llmEnabled=true`, `llmAttempts>0`, and `llmFailures>0`.
+185. Updated monitor workflow env configuration:
+   - `.github/workflows/monitor-production.yml` now sets `COASENSUS_SEMANTIC_FAILURE_STREAK=3`.
+   - `.github/workflows/monitor-staging.yml` now sets `COASENSUS_SEMANTIC_FAILURE_STREAK=3`.
+186. Milestone bookkeeping updated:
+   - `docs/ROADMAP_QUEUE.md` marks `MILESTONE-ALERT-005` complete and promotes `MILESTONE-RATE-006` to active.
+   - `docs/ISSUE_CHECKLIST.md` adds `QA-006` as completed (`explicit monitor alerts for stale feed + semantic failure streaks`).

--- a/docs/ROADMAP_QUEUE.md
+++ b/docs/ROADMAP_QUEUE.md
@@ -14,11 +14,11 @@ Lightweight tracker to keep momentum high while preserving deferred work.
 - [x] `MILESTONE-UI-SEARCH-002` Add text search (question/description) on API + web controls.
 - [x] `MILESTONE-REGION-003` Add region filter controls and expose geo tag in UI.
 - [x] `MILESTONE-TREND-004` Add trending-shift metric (delta vs previous refresh) and card indicator.
-- [ ] `MILESTONE-ALERT-005` Add explicit alerts for repeated semantic failures and stale feed.
+- [x] `MILESTONE-ALERT-005` Add explicit alerts for repeated semantic failures and stale feed.
+- [ ] `MILESTONE-RATE-006` Add per-session rate-limited analytics sampling to reduce noisy events.
 
 ## Next
 
-- [ ] `MILESTONE-RATE-006` Add per-session rate-limited analytics sampling to reduce noisy events.
 - [ ] `MILESTONE-TAXONOMY-007` Add explicit region/category distribution panel to admin diagnostics.
 
 ## Later


### PR DESCRIPTION
## Summary
- add explicit monitor alert codes for empty feed and stale feed
- add semantic failure streak alert (default 3 runs) in monitor script
- wire COASENSUS_SEMANTIC_FAILURE_STREAK=3 in prod/staging monitor workflows
- update roadmap/handoff/progress/checklist for milestone completion

## Validation
- npm run check
- workflow_dispatch on branch:
  - Monitor Production: 22253079906 (success)
  - Monitor Staging: 22253079901 (success)
