### PR TITLE
feat: add per-session analytics rate limiting and sampling

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -16,4 +16,4 @@ Local frontend for the Coasensus feed/cards experience.
 3. On `*.coasensus-web.pages.dev`, the app auto-targets the matching `workers.dev` API endpoint.
 4. Use controls to search by market text, sort (including trending up), filter by category/region, and include rejected markets.
 5. The UI is mobile/desktop responsive and card-based.
-6. Basic analytics events are sent to `/analytics` on the selected API base.
+6. Analytics events are sent to `/analytics` on the selected API base with per-session rate limiting and sampling (to reduce noisy writes).

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -305,6 +305,18 @@ This file is the explicit handoff checkpoint.
 64. Post-merge monitor confirmation:
    - production monitor `22253101327` success
    - staging monitor `22253101546` success.
+65. Rate milestone implementation (`MILESTONE-RATE-006`) completed on `agent/rate-limit-pass1`:
+   - web analytics sender now applies per-session sampling + cooldown policy before POSTing `/api/analytics`.
+   - persisted session-local analytics counters in `localStorage` key `coasensus_analytics_state_v1`.
+   - added global session cap (`ANALYTICS_MAX_EVENTS_PER_SESSION=160`) and event-level limits.
+66. Sampling/rate policy highlights:
+   - `feed_loaded`: sampled at `0.4`, min interval `60s`, max `24` per session.
+   - `pagination_{next,previous}`: sampled at `0.5`, min interval `2s`, max `36` per session.
+   - noisy toggle/search events now include short cooldowns (`~1.2s`) and per-session caps.
+67. Validation:
+   - `npm run check` passed after web analytics throttling updates.
+68. Next recommended milestone:
+   - implement `MILESTONE-TAXONOMY-007` (region/category distribution panel in admin diagnostics).
 
 ## How to start a fresh Codex session
 1. Open terminal in repo: `E:\Coasensus Predictive future`

--- a/docs/ISSUE_CHECKLIST.md
+++ b/docs/ISSUE_CHECKLIST.md
@@ -44,6 +44,7 @@
 - [x] `QA-004` Add deploy verification checklist
 - [x] `QA-005` Define launch gate criteria
 - [x] `QA-006` Add explicit monitor alerts for stale feed and semantic failure streaks
+- [x] `QA-007` Add per-session analytics rate limiting and sampling on web client
 
 ## EPIC-06 Hybrid Semantic Layer (Execution Plan V2)
 - [x] `SEM-001` Add phase-1 bouncer prefilter (query + local gates)

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -527,3 +527,18 @@
    - staging monitor `22253101546` => success.
 190. Monitor output verification from workflow logs:
    - reports now include `semanticFailureStreak`, `alerts.semanticFailureStreak`, and explicit alert-ready telemetry window data in both environments.
+191. Started `MILESTONE-RATE-006` on branch `agent/rate-limit-pass1`.
+192. Added per-session analytics sampling + rate limiting in web client (`apps/web/public/app.js`):
+   - introduced local analytics policy map with per-event `sampleRate`, `minIntervalMs`, and `maxPerSession`.
+   - added session-persistent analytics state (`coasensus_analytics_state_v1`) to maintain event counters across reloads.
+   - added global per-session cap (`ANALYTICS_MAX_EVENTS_PER_SESSION=160`) to avoid runaway writes.
+193. Applied targeted high-noise throttles:
+   - `feed_loaded` now sampled at `0.4`, minimum interval `60s`, max `24` events/session.
+   - pagination events now sampled at `0.5`, minimum interval `2s`.
+   - rapid control change events (`search/sort/category/region/includeRejected`) now rate-limited with cooldowns and caps.
+194. Updated web docs and milestone board:
+   - `apps/web/README.md` now documents rate-limited/sampled analytics behavior.
+   - `docs/ROADMAP_QUEUE.md` marks `MILESTONE-RATE-006` complete and promotes `MILESTONE-TAXONOMY-007` as active.
+   - `docs/ISSUE_CHECKLIST.md` adds `QA-007` completed.
+195. Validation:
+   - `npm run check` => success after analytics throttling implementation.

--- a/docs/ROADMAP_QUEUE.md
+++ b/docs/ROADMAP_QUEUE.md
@@ -15,15 +15,16 @@ Lightweight tracker to keep momentum high while preserving deferred work.
 - [x] `MILESTONE-REGION-003` Add region filter controls and expose geo tag in UI.
 - [x] `MILESTONE-TREND-004` Add trending-shift metric (delta vs previous refresh) and card indicator.
 - [x] `MILESTONE-ALERT-005` Add explicit alerts for repeated semantic failures and stale feed.
-- [ ] `MILESTONE-RATE-006` Add per-session rate-limited analytics sampling to reduce noisy events.
+- [x] `MILESTONE-RATE-006` Add per-session rate-limited analytics sampling to reduce noisy events.
+- [ ] `MILESTONE-TAXONOMY-007` Add explicit region/category distribution panel to admin diagnostics.
 
 ## Next
 
-- [ ] `MILESTONE-TAXONOMY-007` Add explicit region/category distribution panel to admin diagnostics.
+- [ ] `MILESTONE-PERF-008` Add cached feed query path for high-traffic read bursts.
 
 ## Later
 
-- [ ] `MILESTONE-PERF-008` Add cached feed query path for high-traffic read bursts.
+- (none)
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- add per-session analytics policy in web client before /api/analytics posts
- enforce event-level sampling/cooldowns/caps and global session cap
- persist analytics counters in localStorage by session id
- update roadmap/checklist/handoff/progress for RATE-006 completion

## Validation
- npm run check
