### PR TITLE
feat: add region/category taxonomy panel to feed diagnostics

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -323,6 +323,21 @@ This file is the explicit handoff checkpoint.
 70. Post-merge monitor confirmation:
    - production monitor `22253244279` success
    - staging monitor `22253244294` success.
+71. Taxonomy milestone implementation (`MILESTONE-TAXONOMY-007`) completed on `agent/taxonomy-pass1`:
+   - `GET /api/admin/feed-diagnostics` now includes explicit taxonomy distribution payload:
+     - `regionCounts`
+     - `regionCategoryDistribution`
+     - `taxonomyPanel` (`regions`, `categories`, `regionCategory`)
+   - category and region rows now include normalized ratio fields for diagnostics:
+     - `shareOfFeed`
+     - `curatedShareWithinCategory` / `curatedShareWithinRegion`.
+72. Backward compatibility behavior:
+   - existing fields (`counts`, `categoryCounts`, `topDecisionReasons`, `topReasonCodes`) remain present.
+   - when `geo_tag` is unavailable, diagnostics safely fall back to synthetic `World` region totals.
+73. Validation:
+   - `npm run check` passed after taxonomy diagnostics expansion.
+74. Next recommended milestone:
+   - implement `MILESTONE-PERF-008` (cached feed query path for high-traffic read bursts).
 
 ## How to start a fresh Codex session
 1. Open terminal in repo: `E:\Coasensus Predictive future`

--- a/docs/ISSUE_CHECKLIST.md
+++ b/docs/ISSUE_CHECKLIST.md
@@ -45,6 +45,7 @@
 - [x] `QA-005` Define launch gate criteria
 - [x] `QA-006` Add explicit monitor alerts for stale feed and semantic failure streaks
 - [x] `QA-007` Add per-session analytics rate limiting and sampling on web client
+- [x] `QA-008` Add region/category taxonomy distribution to admin feed diagnostics
 
 ## EPIC-06 Hybrid Semantic Layer (Execution Plan V2)
 - [x] `SEM-001` Add phase-1 bouncer prefilter (query + local gates)

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -550,3 +550,21 @@
 198. Post-merge monitor verification on `main`:
    - production monitor `22253244279` => success
    - staging monitor `22253244294` => success.
+199. Started `MILESTONE-TAXONOMY-007` on branch `agent/taxonomy-pass1`.
+200. Expanded admin feed diagnostics taxonomy output in `infra/cloudflare/workers/feed-api/src/index.ts`:
+   - added regional split query (`regionCounts`) using `geo_tag`.
+   - added region x category split query (`regionCategoryDistribution`).
+   - added composite `taxonomyPanel` block with `regions`, `categories`, and `regionCategory` arrays.
+201. Added normalized diagnostics ratios:
+   - category rows now include `shareOfFeed` + `curatedShareWithinCategory`.
+   - region rows now include `shareOfFeed` + `curatedShareWithinRegion`.
+   - region/category rows now include `shareWithinRegion` + `shareOfFeed`.
+202. Added compatibility fallback for environments missing `geo_tag`:
+   - diagnostics synthesize a `World` region panel from existing totals.
+203. Updated Worker docs:
+   - `infra/cloudflare/workers/feed-api/README.md` route list now includes `GET /api/admin/feed-diagnostics`.
+204. Milestone bookkeeping updated:
+   - `docs/ROADMAP_QUEUE.md` marks `MILESTONE-TAXONOMY-007` complete and promotes `MILESTONE-PERF-008` as active.
+   - `docs/ISSUE_CHECKLIST.md` adds `QA-008` completed.
+205. Validation:
+   - `npm run check` => success after taxonomy diagnostics implementation.

--- a/docs/ROADMAP_QUEUE.md
+++ b/docs/ROADMAP_QUEUE.md
@@ -16,11 +16,12 @@ Lightweight tracker to keep momentum high while preserving deferred work.
 - [x] `MILESTONE-TREND-004` Add trending-shift metric (delta vs previous refresh) and card indicator.
 - [x] `MILESTONE-ALERT-005` Add explicit alerts for repeated semantic failures and stale feed.
 - [x] `MILESTONE-RATE-006` Add per-session rate-limited analytics sampling to reduce noisy events.
-- [ ] `MILESTONE-TAXONOMY-007` Add explicit region/category distribution panel to admin diagnostics.
+- [x] `MILESTONE-TAXONOMY-007` Add explicit region/category distribution panel to admin diagnostics.
+- [ ] `MILESTONE-PERF-008` Add cached feed query path for high-traffic read bursts.
 
 ## Next
 
-- [ ] `MILESTONE-PERF-008` Add cached feed query path for high-traffic read bursts.
+- (none)
 
 ## Later
 

--- a/infra/cloudflare/workers/feed-api/README.md
+++ b/infra/cloudflare/workers/feed-api/README.md
@@ -7,8 +7,9 @@ Cloudflare Worker API for Coasensus.
 2. `GET /api/feed?page=1&pageSize=20&sort=trend&q=election&region=US`
 3. `POST /api/admin/refresh-feed` (manual ingestion refresh; requires `X-Admin-Token` if `COASENSUS_ADMIN_REFRESH_TOKEN` secret is set)
 4. `GET /api/admin/semantic-metrics?limit=30` (admin-protected telemetry snapshot)
-5. `POST /api/analytics`
-6. `GET /api/analytics?limit=50`
+5. `GET /api/admin/feed-diagnostics` (admin-protected feed diagnostics + taxonomy panel)
+6. `POST /api/analytics`
+7. `GET /api/analytics?limit=50`
 
 ## Data source
 Reads from D1 tables:


### PR DESCRIPTION
## Summary
- expand /api/admin/feed-diagnostics with explicit taxonomy outputs
- add egionCounts, egionCategoryDistribution, and 	axonomyPanel
- add ratio fields for category/region distribution rows
- keep backward compatibility for existing diagnostics keys; fallback to World panel when geo_tag is unavailable
- update roadmap/checklist/handoff/progress docs

## Validation
- npm run check
