### PR TITLE
feat: add launch stability readiness gate

### DIFF
--- a/.github/workflows/launch-stability.yml
+++ b/.github/workflows/launch-stability.yml
@@ -1,0 +1,44 @@
+name: Launch Stability
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 * * * *"
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  readiness:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Evaluate 24h Launch Stability
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COASENSUS_STABILITY_WINDOW_HOURS: "24"
+          COASENSUS_STABILITY_MAX_FAILURES: "0"
+          COASENSUS_STABILITY_MAX_EMPTY_HOURS: "0"
+          COASENSUS_STABILITY_PRODUCTION_WORKFLOW: "monitor-production.yml"
+          COASENSUS_STABILITY_STAGING_WORKFLOW: "monitor-staging.yml"
+          COASENSUS_STABILITY_PRODUCTION_MAX_GAP_MINUTES: "40"
+          COASENSUS_STABILITY_STAGING_MAX_GAP_MINUTES: "70"
+          COASENSUS_STABILITY_PRODUCTION_MIN_RUNS: "80"
+          COASENSUS_STABILITY_STAGING_MIN_RUNS: "40"
+        run: node scripts/launch-stability.mjs
+
+      - name: Upload Launch Stability Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: launch-stability-${{ github.run_id }}
+          path: artifacts/launch-status.*
+          if-no-files-found: error

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -383,6 +383,26 @@ This file is the explicit handoff checkpoint.
 90. Post-sync monitor confirmation:
    - production monitor `22253876652` success
    - staging monitor `22253876653` success.
+91. Launch-stability milestone implementation (`MILESTONE-LAUNCH-STABILITY-009`) completed on `agent/launch-stability-pass1`:
+   - added script `scripts/launch-stability.mjs` to compute 24h readiness from monitor workflow history.
+   - output artifacts:
+     - `artifacts/launch-status.json`
+     - `artifacts/launch-status.md`
+   - workflow returns non-zero when gate criteria are not met.
+92. New workflow added:
+   - `.github/workflows/launch-stability.yml`
+   - schedule: hourly (`17 * * * *`) + manual dispatch.
+   - uploads launch-status artifacts even when readiness fails.
+93. Launch-stability checks include:
+   - run count floors (prod/staging), failure threshold, empty-hour threshold, max run-gap threshold.
+   - per-hour pass/fail rollup to show stability coverage across window.
+94. Launch docs/queue updates:
+   - `docs/LAUNCH_GATES.md` now includes Launch Stability workflow in go-live checklist.
+   - `docs/ROADMAP_QUEUE.md` marks `MILESTONE-LAUNCH-STABILITY-009` complete and promotes `MILESTONE-CATEGORY-SANITY-010`.
+95. Validation:
+   - `npm run check` passed.
+   - local script success-path validated with short-window env overrides.
+   - note: strict 24h window currently reports `overallReady=false` due historical failure/gaps, which is expected until the next clean stability window.
 
 ## How to start a fresh Codex session
 1. Open terminal in repo: `E:\Coasensus Predictive future`

--- a/docs/ISSUE_CHECKLIST.md
+++ b/docs/ISSUE_CHECKLIST.md
@@ -47,6 +47,7 @@
 - [x] `QA-007` Add per-session analytics rate limiting and sampling on web client
 - [x] `QA-008` Add region/category taxonomy distribution to admin feed diagnostics
 - [x] `QA-009` Add cached feed query path for burst traffic on `/api/feed`
+- [x] `QA-010` Add automated 24h launch-stability readiness checker for monitor workflows
 
 ## EPIC-06 Hybrid Semantic Layer (Execution Plan V2)
 - [x] `SEM-001` Add phase-1 bouncer prefilter (query + local gates)

--- a/docs/LAUNCH_GATES.md
+++ b/docs/LAUNCH_GATES.md
@@ -49,4 +49,5 @@ This document defines go/no-go criteria for public launch decisions.
 3. Confirm DNS and HTTPS for:
    - `https://coasensus.com`
    - `https://staging.coasensus.com`
-4. Log launch decision + timestamp + responsible owner in `docs/PROGRESS_LOG.md`.
+4. Run `Launch Stability` workflow (`.github/workflows/launch-stability.yml`) and verify `overallReady=true` for the 24h window.
+5. Log launch decision + timestamp + responsible owner in `docs/PROGRESS_LOG.md`.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -631,3 +631,26 @@
 228. Monitor verification after docs sync:
    - production monitor `22253876652` => success
    - staging monitor `22253876653` => success.
+229. Started `MILESTONE-LAUNCH-STABILITY-009` on branch `agent/launch-stability-pass1`.
+230. Added launch-stability evaluator script:
+   - `scripts/launch-stability.mjs` queries GitHub Actions workflow runs for monitor workflows across a rolling window (default 24h).
+   - computes per-workflow readiness from:
+     - minimum run count
+     - failure-count threshold
+     - empty-hour threshold
+     - maximum observed gap between runs.
+231. Added artifact and summary outputs:
+   - script writes `artifacts/launch-status.json` + `artifacts/launch-status.md`.
+   - writes markdown summary to `GITHUB_STEP_SUMMARY` when available.
+232. Added Launch Stability workflow:
+   - `.github/workflows/launch-stability.yml`
+   - schedule: hourly (`17 * * * *`) plus manual dispatch.
+   - uploads launch-status artifacts with `if: always()` so diagnostics persist on failure.
+233. Queue and gate docs updated:
+   - `docs/ROADMAP_QUEUE.md` marks `MILESTONE-LAUNCH-STABILITY-009` complete and promotes `MILESTONE-CATEGORY-SANITY-010`.
+   - `docs/LAUNCH_GATES.md` go-live checklist now requires successful Launch Stability workflow check.
+   - `docs/ISSUE_CHECKLIST.md` adds `QA-010` completed.
+234. Validation:
+   - `npm run check` => success.
+   - local strict 24h run intentionally returned non-ready due historical monitor gap/failure data (expected gate behavior).
+   - local short-window override run returned `overallReady=true`, validating success path and artifact generation.

--- a/docs/ROADMAP_QUEUE.md
+++ b/docs/ROADMAP_QUEUE.md
@@ -18,11 +18,11 @@ Lightweight tracker to keep momentum high while preserving deferred work.
 - [x] `MILESTONE-RATE-006` Add per-session rate-limited analytics sampling to reduce noisy events.
 - [x] `MILESTONE-TAXONOMY-007` Add explicit region/category distribution panel to admin diagnostics.
 - [x] `MILESTONE-PERF-008` Add cached feed query path for high-traffic read bursts.
-- [ ] `MILESTONE-LAUNCH-STABILITY-009` Automate 24h launch-stability gate tracking (monitor pass window + readiness status).
+- [x] `MILESTONE-LAUNCH-STABILITY-009` Automate 24h launch-stability gate tracking (monitor pass window + readiness status).
+- [ ] `MILESTONE-CATEGORY-SANITY-010` Add automated category-dominance checks for top feed cards.
 
 ## Next
 
-- [ ] `MILESTONE-CATEGORY-SANITY-010` Add automated category-dominance checks for top feed cards.
 - [ ] `MILESTONE-EDITORIAL-SPOTCHECK-011` Add top-20 feed snapshot + reviewer log workflow.
 - [ ] `MILESTONE-DASHBOARD-012` Add lightweight admin diagnostics dashboard view (read-only).
 

--- a/scripts/launch-stability.mjs
+++ b/scripts/launch-stability.mjs
@@ -1,0 +1,350 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { execSync } from "node:child_process";
+
+const apiBase = (process.env.GITHUB_API_URL || "https://api.github.com").replace(/\/+$/, "");
+const repository = process.env.GITHUB_REPOSITORY || deriveRepositoryFromGitRemote();
+const branch = process.env.COASENSUS_STABILITY_BRANCH || "main";
+const windowHours = asPositiveInt(process.env.COASENSUS_STABILITY_WINDOW_HOURS, 24, 1, 168);
+const maxAllowedFailures = asPositiveInt(process.env.COASENSUS_STABILITY_MAX_FAILURES, 0, 0, 1000);
+const maxAllowedEmptyHours = asPositiveInt(process.env.COASENSUS_STABILITY_MAX_EMPTY_HOURS, 0, 0, 168);
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || "";
+
+const definitions = [
+  {
+    key: "production",
+    label: "Monitor Production",
+    workflow: process.env.COASENSUS_STABILITY_PRODUCTION_WORKFLOW || "monitor-production.yml",
+    maxGapMinutes: asPositiveInt(process.env.COASENSUS_STABILITY_PRODUCTION_MAX_GAP_MINUTES, 40, 5, 240),
+    minRuns: asPositiveInt(process.env.COASENSUS_STABILITY_PRODUCTION_MIN_RUNS, 80, 1, 1000),
+  },
+  {
+    key: "staging",
+    label: "Monitor Staging",
+    workflow: process.env.COASENSUS_STABILITY_STAGING_WORKFLOW || "monitor-staging.yml",
+    maxGapMinutes: asPositiveInt(process.env.COASENSUS_STABILITY_STAGING_MAX_GAP_MINUTES, 70, 5, 240),
+    minRuns: asPositiveInt(process.env.COASENSUS_STABILITY_STAGING_MIN_RUNS, 40, 1, 1000),
+  },
+];
+
+function asPositiveInt(value, fallback, min, max) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, parsed));
+}
+
+function toIsoHour(date) {
+  const d = new Date(date);
+  d.setUTCMinutes(0, 0, 0);
+  return d.toISOString();
+}
+
+function parseRepository(raw) {
+  const [owner, repo] = String(raw || "").split("/");
+  return {
+    owner: owner || "",
+    repo: repo || "",
+  };
+}
+
+function deriveRepositoryFromGitRemote() {
+  try {
+    const remote = execSync("git config --get remote.origin.url", { encoding: "utf8" }).trim();
+    if (!remote) {
+      return "";
+    }
+    const cleaned = remote.replace(/\.git$/, "");
+    const sshMatch = cleaned.match(/github\.com[:/](.+?)\/(.+)$/i);
+    if (sshMatch) {
+      return `${sshMatch[1]}/${sshMatch[2]}`;
+    }
+    return "";
+  } catch {
+    return "";
+  }
+}
+
+function ensure(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function fetchGitHub(pathname, tokenValue) {
+  const response = await fetch(`${apiBase}${pathname}`, {
+    headers: {
+      Authorization: `Bearer ${tokenValue}`,
+      Accept: "application/vnd.github+json",
+      "User-Agent": "coasensus-launch-stability-script",
+    },
+  });
+  const text = await response.text();
+  let data = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    data = null;
+  }
+  if (!response.ok) {
+    throw new Error(`GitHub API ${response.status} ${response.statusText}: ${text.slice(0, 500)}`);
+  }
+  return data;
+}
+
+function isFailureConclusion(conclusion) {
+  return (
+    conclusion === "failure" ||
+    conclusion === "timed_out" ||
+    conclusion === "cancelled" ||
+    conclusion === "action_required"
+  );
+}
+
+async function fetchCompletedRuns({ owner, repo, workflow, sinceIso, untilIso }) {
+  const runs = [];
+  let page = 1;
+  while (page <= 5) {
+    const query = new URLSearchParams({
+      branch,
+      per_page: "100",
+      page: String(page),
+      exclude_pull_requests: "true",
+    });
+    const payload = await fetchGitHub(
+      `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions/workflows/${encodeURIComponent(workflow)}/runs?${query.toString()}`,
+      token
+    );
+    const batch = Array.isArray(payload?.workflow_runs) ? payload.workflow_runs : [];
+    if (!batch.length) {
+      break;
+    }
+
+    for (const run of batch) {
+      const createdAt = String(run?.created_at || "");
+      if (!createdAt) continue;
+      if (createdAt < sinceIso) {
+        return runs.sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt));
+      }
+      if (createdAt > untilIso) {
+        continue;
+      }
+      if (String(run?.status) !== "completed") {
+        continue;
+      }
+      runs.push({
+        id: Number(run?.id ?? 0),
+        name: String(run?.name || ""),
+        runNumber: Number(run?.run_number ?? 0),
+        event: String(run?.event || ""),
+        conclusion: String(run?.conclusion || ""),
+        createdAt,
+        updatedAt: String(run?.updated_at || ""),
+        url: String(run?.html_url || ""),
+      });
+    }
+    if (batch.length < 100) {
+      break;
+    }
+    page += 1;
+  }
+  return runs.sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt));
+}
+
+function summarizeRuns(runs, { nowMs, sinceMs, hours, maxGapMinutes, minRuns }) {
+  const successCount = runs.filter((run) => run.conclusion === "success").length;
+  const failureRuns = runs.filter((run) => isFailureConclusion(run.conclusion));
+  const failureCount = failureRuns.length;
+  const totalCount = runs.length;
+  const bucketMs = 60 * 60 * 1000;
+
+  const hourly = [];
+  for (let index = 0; index < hours; index += 1) {
+    const startMs = sinceMs + index * bucketMs;
+    hourly.push({
+      hourStart: toIsoHour(startMs),
+      total: 0,
+      success: 0,
+      failure: 0,
+    });
+  }
+
+  for (const run of runs) {
+    const runMs = Date.parse(run.createdAt);
+    const idx = Math.floor((runMs - sinceMs) / bucketMs);
+    if (idx < 0 || idx >= hourly.length) {
+      continue;
+    }
+    const row = hourly[idx];
+    row.total += 1;
+    if (run.conclusion === "success") {
+      row.success += 1;
+    } else if (isFailureConclusion(run.conclusion)) {
+      row.failure += 1;
+    }
+  }
+
+  const emptyHours = hourly.filter((row) => row.total === 0).map((row) => row.hourStart);
+  const failureHours = hourly.filter((row) => row.failure > 0).map((row) => row.hourStart);
+
+  let maxGapObservedMinutes = 0;
+  if (runs.length === 0) {
+    maxGapObservedMinutes = Number(((nowMs - sinceMs) / 60000).toFixed(2));
+  } else {
+    let previousMs = sinceMs;
+    for (const run of runs) {
+      const runMs = Date.parse(run.createdAt);
+      const gapMinutes = (runMs - previousMs) / 60000;
+      if (gapMinutes > maxGapObservedMinutes) {
+        maxGapObservedMinutes = gapMinutes;
+      }
+      previousMs = runMs;
+    }
+    const tailGapMinutes = (nowMs - previousMs) / 60000;
+    if (tailGapMinutes > maxGapObservedMinutes) {
+      maxGapObservedMinutes = tailGapMinutes;
+    }
+  }
+  maxGapObservedMinutes = Number(maxGapObservedMinutes.toFixed(2));
+
+  const reasons = [];
+  if (totalCount < minRuns) {
+    reasons.push(`run_count_below_min (${totalCount} < ${minRuns})`);
+  }
+  if (failureCount > maxAllowedFailures) {
+    reasons.push(`failures_exceeded (${failureCount} > ${maxAllowedFailures})`);
+  }
+  if (emptyHours.length > maxAllowedEmptyHours) {
+    reasons.push(`empty_hours_exceeded (${emptyHours.length} > ${maxAllowedEmptyHours})`);
+  }
+  if (maxGapObservedMinutes > maxGapMinutes) {
+    reasons.push(`max_gap_exceeded (${maxGapObservedMinutes} > ${maxGapMinutes} minutes)`);
+  }
+
+  return {
+    ready: reasons.length === 0,
+    reasons,
+    totalCount,
+    successCount,
+    failureCount,
+    maxGapObservedMinutes,
+    maxGapAllowedMinutes: maxGapMinutes,
+    minRunsRequired: minRuns,
+    emptyHours,
+    failureHours,
+    hourly,
+    latestRun: runs[runs.length - 1] ?? null,
+    sampleFailures: failureRuns.slice(-5),
+  };
+}
+
+function renderMarkdown(report) {
+  const lines = [];
+  lines.push("# Launch Stability Status");
+  lines.push("");
+  lines.push(`- Generated: ${report.generatedAt}`);
+  lines.push(`- Repository: ${report.repository}`);
+  lines.push(`- Branch: ${report.branch}`);
+  lines.push(`- Window: ${report.windowHours}h`);
+  lines.push(`- Overall Ready: ${report.overallReady ? "YES" : "NO"}`);
+  lines.push("");
+  lines.push("| Workflow | Ready | Runs | Success | Failures | Max Gap (min) | Empty Hours |");
+  lines.push("|---|---:|---:|---:|---:|---:|---:|");
+  for (const workflow of report.workflows) {
+    lines.push(
+      `| ${workflow.label} | ${workflow.ready ? "YES" : "NO"} | ${workflow.totalCount} | ${workflow.successCount} | ${workflow.failureCount} | ${workflow.maxGapObservedMinutes} | ${workflow.emptyHours.length} |`
+    );
+  }
+
+  for (const workflow of report.workflows) {
+    lines.push("");
+    lines.push(`## ${workflow.label}`);
+    lines.push(`- Ready: ${workflow.ready ? "YES" : "NO"}`);
+    lines.push(`- Reasons: ${workflow.reasons.length ? workflow.reasons.join(", ") : "none"}`);
+    if (workflow.latestRun) {
+      lines.push(`- Latest run: ${workflow.latestRun.createdAt} (${workflow.latestRun.conclusion})`);
+      lines.push(`- Latest run URL: ${workflow.latestRun.url}`);
+    }
+  }
+
+  lines.push("");
+  lines.push("## Raw Artifact");
+  lines.push("- JSON artifact: `artifacts/launch-status.json`");
+  return `${lines.join("\n")}\n`;
+}
+
+async function main() {
+  const { owner, repo } = parseRepository(repository);
+  ensure(owner && repo, "Missing GITHUB_REPOSITORY (expected owner/repo)");
+  ensure(token.trim().length > 0, "Missing GitHub token (`GITHUB_TOKEN` or `GH_TOKEN`)");
+
+  const nowMs = Date.now();
+  const sinceMs = nowMs - windowHours * 60 * 60 * 1000;
+  const sinceIso = new Date(sinceMs).toISOString();
+  const untilIso = new Date(nowMs).toISOString();
+
+  const workflows = [];
+  for (const definition of definitions) {
+    const runs = await fetchCompletedRuns({
+      owner,
+      repo,
+      workflow: definition.workflow,
+      sinceIso,
+      untilIso,
+    });
+    const summary = summarizeRuns(runs, {
+      nowMs,
+      sinceMs,
+      hours: windowHours,
+      maxGapMinutes: definition.maxGapMinutes,
+      minRuns: definition.minRuns,
+    });
+    workflows.push({
+      key: definition.key,
+      label: definition.label,
+      workflow: definition.workflow,
+      ...summary,
+    });
+  }
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    repository,
+    branch,
+    windowHours,
+    maxAllowedFailures,
+    maxAllowedEmptyHours,
+    overallReady: workflows.every((workflow) => workflow.ready),
+    workflows,
+  };
+
+  const outputDir = path.resolve("artifacts");
+  await mkdir(outputDir, { recursive: true });
+  const jsonPath = path.join(outputDir, "launch-status.json");
+  const mdPath = path.join(outputDir, "launch-status.md");
+  await writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  await writeFile(mdPath, renderMarkdown(report), "utf8");
+
+  const stepSummaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (stepSummaryPath) {
+    await writeFile(stepSummaryPath, renderMarkdown(report), "utf8");
+  }
+
+  console.log(JSON.stringify(report, null, 2));
+  if (!report.overallReady) {
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  const output = {
+    ok: false,
+    message: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : null,
+  };
+  console.error(JSON.stringify(output, null, 2));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary\n- add hourly/manual Launch Stability workflow\n- add launch-stability script to evaluate 24h monitor readiness\n- update queue, launch gates, and progress/handoff docs for QA-010\n\n## Validation\n- npm run check\n- local launch-stability strict window (expected non-ready on historical gaps)\n- local launch-stability short-window override success path\n