### PR TITLE
feat: add read-only admin diagnostics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,8 @@ npm run dev:feed-api
 npm run dev:web
 npm run monitor:prod
 ```
+
+## Admin diagnostics
+- Feed UI: `https://coasensus.com`
+- Read-only diagnostics dashboard: `https://coasensus.com/admin.html`
+- Dashboard uses existing admin endpoints and requires an admin token for protected diagnostics routes.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -9,6 +9,7 @@ Local frontend for the Coasensus feed/cards experience.
    - `npm run dev:web`
 3. Open:
    - `http://localhost:3000`
+   - `http://localhost:3000/admin.html` (read-only diagnostics dashboard)
 
 ## Runtime behavior
 1. In local mode (`localhost`), app calls `http://localhost:8787/feed` by default.
@@ -17,3 +18,9 @@ Local frontend for the Coasensus feed/cards experience.
 4. Use controls to search by market text, sort (including trending up), filter by category/region, and include rejected markets.
 5. The UI is mobile/desktop responsive and card-based.
 6. Analytics events are sent to `/analytics` on the selected API base with per-session rate limiting and sampling (to reduce noisy writes).
+7. Admin diagnostics page reads:
+   - `/api/health`
+   - `/api/feed`
+   - `/api/admin/semantic-metrics` (requires admin token)
+   - `/api/admin/feed-diagnostics` (requires admin token)
+8. Admin token is entered in the dashboard UI and stored in `sessionStorage` for the browser session only.

--- a/apps/web/public/admin.html
+++ b/apps/web/public/admin.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Coasensus Admin Diagnostics</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <div class="shell admin-shell">
+      <header class="hero admin-hero">
+        <p class="eyebrow">Coasensus Admin</p>
+        <h1>Read-only diagnostics dashboard.</h1>
+        <p class="sub">
+          This view reads existing API diagnostics endpoints. It does not write data and requires an admin token for
+          protected routes.
+        </p>
+        <p class="hero-links">
+          <a class="admin-link" href="/">Back to Feed</a>
+        </p>
+      </header>
+
+      <section class="controls admin-controls">
+        <label>
+          <span>API Base</span>
+          <input id="apiBase" type="text" placeholder="https://coasensus.com/api" />
+        </label>
+        <label>
+          <span>Admin Token</span>
+          <input id="adminToken" type="password" placeholder="Paste X-Admin-Token value" />
+        </label>
+        <label>
+          <span>Semantic Limit</span>
+          <input id="semanticLimit" type="number" min="1" max="200" value="20" />
+        </label>
+        <label>
+          <span>Top N</span>
+          <input id="topN" type="number" min="1" max="100" value="20" />
+        </label>
+        <button id="refresh" class="button">Refresh Diagnostics</button>
+      </section>
+
+      <section id="status" class="status"></section>
+
+      <section class="dashboard-grid">
+        <article class="card metric-card">
+          <h3>Service</h3>
+          <div id="serviceHealth" class="metric-value">n/a</div>
+          <p id="serviceMeta" class="metric-sub">Waiting for refresh.</p>
+        </article>
+
+        <article class="card metric-card">
+          <h3>Feed Size</h3>
+          <div id="feedTotal" class="metric-value">n/a</div>
+          <p id="feedMeta" class="metric-sub">Top card snapshot pending.</p>
+        </article>
+
+        <article class="card metric-card">
+          <h3>Latest Refresh</h3>
+          <div id="latestRunAt" class="metric-value">n/a</div>
+          <p id="latestRunMeta" class="metric-sub">Semantic run pending.</p>
+        </article>
+
+        <article class="card metric-card">
+          <h3>LLM Success</h3>
+          <div id="llmSuccess" class="metric-value">n/a</div>
+          <p id="llmMeta" class="metric-sub">Needs semantic telemetry.</p>
+        </article>
+      </section>
+
+      <section class="card panel">
+        <h2>Top-N Composition</h2>
+        <p class="panel-sub">Dominant category and top-card category mix from feed diagnostics.</p>
+        <div id="compositionStatus" class="panel-note">No diagnostics loaded yet.</div>
+        <div id="compositionTable"></div>
+      </section>
+
+      <section class="card panel">
+        <h2>Semantic Runs</h2>
+        <p class="panel-sub">Recent refresh runs and LLM attempt outcomes.</p>
+        <div id="semanticRunsTable"></div>
+      </section>
+
+      <section class="card panel">
+        <h2>Semantic Aggregates</h2>
+        <p class="panel-sub">Prompt/model aggregate success and cache behavior.</p>
+        <div id="semanticAggTable"></div>
+      </section>
+
+      <section class="card panel">
+        <h2>Taxonomy Distribution</h2>
+        <p class="panel-sub">Category and region totals from feed diagnostics.</p>
+        <div class="split-panels">
+          <div>
+            <h3>By Category</h3>
+            <div id="categoryTable"></div>
+          </div>
+          <div>
+            <h3>By Region</h3>
+            <div id="regionTable"></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="card panel">
+        <h2>Decision Signals</h2>
+        <p class="panel-sub">Top decision reasons and reason codes in curated feed.</p>
+        <div class="split-panels">
+          <div>
+            <h3>Decision Reasons</h3>
+            <div id="decisionTable"></div>
+          </div>
+          <div>
+            <h3>Reason Codes</h3>
+            <div id="reasonCodeTable"></div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <script src="/admin.js" defer></script>
+  </body>
+</html>

--- a/apps/web/public/admin.js
+++ b/apps/web/public/admin.js
@@ -1,0 +1,436 @@
+const SETTINGS_KEY = "coasensus_admin_dashboard_settings_v1";
+
+function resolveApiBaseDefault() {
+  if (typeof window.COASENSUS_API_BASE === "string" && window.COASENSUS_API_BASE.trim()) {
+    return normalizeApiBase(window.COASENSUS_API_BASE.trim());
+  }
+
+  const host = window.location.hostname;
+  const isLocalhost = host === "localhost" || host === "127.0.0.1";
+  if (isLocalhost) {
+    return "http://localhost:8787/api";
+  }
+  if (host.endsWith(".coasensus-web.pages.dev")) {
+    if (host.startsWith("staging.")) {
+      return "https://coasensus-api-staging.tahmidahmad1970.workers.dev/api";
+    }
+    return "https://coasensus-api.tahmidahmad1970.workers.dev/api";
+  }
+  return `${window.location.origin}/api`;
+}
+
+function normalizeApiBase(value) {
+  const trimmed = String(value || "").trim().replace(/\/+$/, "");
+  if (!trimmed) {
+    return resolveApiBaseDefault();
+  }
+  if (trimmed.endsWith("/api")) {
+    return trimmed;
+  }
+  return `${trimmed}/api`;
+}
+
+function asPositiveInt(value, fallback, min, max) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, parsed));
+}
+
+function fmtNum(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num.toLocaleString() : "n/a";
+}
+
+function fmtPercent(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return "n/a";
+  return `${(num * 100).toFixed(1)}%`;
+}
+
+function fmtDateTime(value) {
+  if (!value) return "n/a";
+  const date = new Date(String(value));
+  if (Number.isNaN(date.getTime())) return "n/a";
+  return date.toLocaleString();
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+async function fetchJson(url, token) {
+  const headers = {
+    Accept: "application/json",
+  };
+  if (token) {
+    headers["X-Admin-Token"] = token;
+  }
+
+  const response = await fetch(url, { headers });
+  const text = await response.text();
+  let data = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    data = null;
+  }
+
+  if (!response.ok) {
+    const detail = data && typeof data === "object" && "error" in data ? String(data.error) : text.slice(0, 200);
+    throw new Error(`${response.status} ${response.statusText}: ${detail}`);
+  }
+  if (!data || typeof data !== "object") {
+    throw new Error("Invalid JSON response");
+  }
+  return data;
+}
+
+function renderTable(container, columns, rows, emptyMessage) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    container.innerHTML = `<p class="table-empty">${escapeHtml(emptyMessage)}</p>`;
+    return;
+  }
+
+  const head = columns
+    .map((column) => `<th>${escapeHtml(column.label)}</th>`)
+    .join("");
+  const body = rows
+    .map((row) => {
+      const cells = columns
+        .map((column) => {
+          const raw = typeof column.render === "function" ? column.render(row) : row[column.key];
+          return `<td>${escapeHtml(raw ?? "n/a")}</td>`;
+        })
+        .join("");
+      return `<tr>${cells}</tr>`;
+    })
+    .join("");
+
+  container.innerHTML = `
+    <div class="table-wrap">
+      <table class="diag-table">
+        <thead><tr>${head}</tr></thead>
+        <tbody>${body}</tbody>
+      </table>
+    </div>
+  `;
+}
+
+const el = {
+  apiBase: document.getElementById("apiBase"),
+  adminToken: document.getElementById("adminToken"),
+  semanticLimit: document.getElementById("semanticLimit"),
+  topN: document.getElementById("topN"),
+  refresh: document.getElementById("refresh"),
+  status: document.getElementById("status"),
+  serviceHealth: document.getElementById("serviceHealth"),
+  serviceMeta: document.getElementById("serviceMeta"),
+  feedTotal: document.getElementById("feedTotal"),
+  feedMeta: document.getElementById("feedMeta"),
+  latestRunAt: document.getElementById("latestRunAt"),
+  latestRunMeta: document.getElementById("latestRunMeta"),
+  llmSuccess: document.getElementById("llmSuccess"),
+  llmMeta: document.getElementById("llmMeta"),
+  compositionStatus: document.getElementById("compositionStatus"),
+  compositionTable: document.getElementById("compositionTable"),
+  semanticRunsTable: document.getElementById("semanticRunsTable"),
+  semanticAggTable: document.getElementById("semanticAggTable"),
+  categoryTable: document.getElementById("categoryTable"),
+  regionTable: document.getElementById("regionTable"),
+  decisionTable: document.getElementById("decisionTable"),
+  reasonCodeTable: document.getElementById("reasonCodeTable"),
+};
+
+function readSettings() {
+  const defaults = {
+    apiBase: resolveApiBaseDefault(),
+    adminToken: "",
+    semanticLimit: 20,
+    topN: 20,
+  };
+
+  try {
+    const raw = window.sessionStorage.getItem(SETTINGS_KEY);
+    if (!raw) return defaults;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return defaults;
+
+    return {
+      apiBase: normalizeApiBase(parsed.apiBase || defaults.apiBase),
+      adminToken: String(parsed.adminToken || ""),
+      semanticLimit: asPositiveInt(parsed.semanticLimit, 20, 1, 200),
+      topN: asPositiveInt(parsed.topN, 20, 1, 100),
+    };
+  } catch {
+    return defaults;
+  }
+}
+
+function writeSettings(settings) {
+  try {
+    window.sessionStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+let state = readSettings();
+
+function syncInputs() {
+  el.apiBase.value = state.apiBase;
+  el.adminToken.value = state.adminToken;
+  el.semanticLimit.value = String(state.semanticLimit);
+  el.topN.value = String(state.topN);
+}
+
+function syncStateFromInputs() {
+  state = {
+    apiBase: normalizeApiBase(el.apiBase.value),
+    adminToken: String(el.adminToken.value || "").trim(),
+    semanticLimit: asPositiveInt(el.semanticLimit.value, 20, 1, 200),
+    topN: asPositiveInt(el.topN.value, 20, 1, 100),
+  };
+  writeSettings(state);
+  syncInputs();
+}
+
+function setStatus(message, type = "neutral") {
+  el.status.textContent = message;
+  el.status.className = `status dashboard-status status-${type}`;
+}
+
+function renderComposition(diag) {
+  const composition = diag?.topPageComposition ?? null;
+  if (!composition || !Array.isArray(composition.categories)) {
+    el.compositionStatus.textContent = "Top-N composition not available.";
+    el.compositionTable.innerHTML = "";
+    return;
+  }
+
+  const dominant = composition.dominantCategory;
+  const dominantLabel = dominant
+    ? `${dominant.category} (${fmtPercent(dominant.shareOfTopN)} of top ${composition.topNEvaluated || 0})`
+    : "n/a";
+  el.compositionStatus.textContent = `Dominant category: ${dominantLabel}`;
+
+  renderTable(
+    el.compositionTable,
+    [
+      { key: "category", label: "Category" },
+      { key: "count", label: "Count" },
+      { key: "shareOfTopN", label: "Share", render: (row) => fmtPercent(row.shareOfTopN) },
+    ],
+    composition.categories,
+    "No top-N composition rows."
+  );
+}
+
+function renderSemanticRuns(semantic) {
+  const runs = Array.isArray(semantic?.runs) ? semantic.runs : [];
+  renderTable(
+    el.semanticRunsTable,
+    [
+      { key: "runId", label: "Run ID" },
+      { key: "fetchedAt", label: "Fetched At", render: (row) => fmtDateTime(row.fetchedAt) },
+      { key: "llmProvider", label: "Provider" },
+      { key: "llmModel", label: "Model" },
+      { key: "llmAttempts", label: "Attempts" },
+      { key: "llmFailures", label: "Failures" },
+      { key: "llmSuccessRate", label: "Success", render: (row) => fmtPercent(row.llmSuccessRate) },
+      { key: "curatedCount", label: "Curated" },
+      { key: "rejectedCount", label: "Rejected" },
+      { key: "totalMs", label: "Total ms" },
+    ],
+    runs,
+    "No semantic runs found."
+  );
+}
+
+function renderSemanticAgg(semantic) {
+  const rows = Array.isArray(semantic?.aggregates) ? semantic.aggregates : [];
+  renderTable(
+    el.semanticAggTable,
+    [
+      { key: "promptVersion", label: "Prompt Version" },
+      { key: "llmProvider", label: "Provider" },
+      { key: "llmModel", label: "Model" },
+      { key: "runCount", label: "Runs" },
+      { key: "llmAttempts", label: "Attempts" },
+      { key: "llmFailures", label: "Failures" },
+      { key: "llmSuccessRate", label: "Success", render: (row) => fmtPercent(row.llmSuccessRate) },
+      { key: "cacheHits", label: "Cache Hits" },
+      { key: "cacheMisses", label: "Cache Misses" },
+      { key: "avgTotalMs", label: "Avg ms" },
+    ],
+    rows,
+    "No semantic aggregates found."
+  );
+}
+
+function renderDiagnosticsTables(diag) {
+  renderTable(
+    el.categoryTable,
+    [
+      { key: "category", label: "Category" },
+      { key: "total", label: "Total" },
+      { key: "curated", label: "Curated" },
+      { key: "rejected", label: "Rejected" },
+      { key: "shareOfFeed", label: "Feed Share", render: (row) => fmtPercent(row.shareOfFeed) },
+      {
+        key: "curatedShareWithinCategory",
+        label: "Curated Share",
+        render: (row) => fmtPercent(row.curatedShareWithinCategory),
+      },
+    ],
+    Array.isArray(diag?.categoryCounts) ? diag.categoryCounts : [],
+    "No category distribution rows."
+  );
+
+  renderTable(
+    el.regionTable,
+    [
+      { key: "region", label: "Region" },
+      { key: "total", label: "Total" },
+      { key: "curated", label: "Curated" },
+      { key: "rejected", label: "Rejected" },
+      { key: "shareOfFeed", label: "Feed Share", render: (row) => fmtPercent(row.shareOfFeed) },
+      {
+        key: "curatedShareWithinRegion",
+        label: "Curated Share",
+        render: (row) => fmtPercent(row.curatedShareWithinRegion),
+      },
+    ],
+    Array.isArray(diag?.regionCounts) ? diag.regionCounts : [],
+    "No region distribution rows."
+  );
+
+  renderTable(
+    el.decisionTable,
+    [
+      { key: "decisionReason", label: "Decision Reason" },
+      { key: "count", label: "Count" },
+    ],
+    Array.isArray(diag?.topDecisionReasons) ? diag.topDecisionReasons : [],
+    "No decision reason rows."
+  );
+
+  renderTable(
+    el.reasonCodeTable,
+    [
+      { key: "reasonCode", label: "Reason Code" },
+      { key: "count", label: "Count" },
+    ],
+    Array.isArray(diag?.topReasonCodes) ? diag.topReasonCodes : [],
+    "No reason code rows."
+  );
+}
+
+function renderSummary(health, feed, semantic, diag) {
+  el.serviceHealth.textContent = health?.status || "n/a";
+  el.serviceMeta.textContent = `Service: ${health?.service || "unknown"}`;
+
+  el.feedTotal.textContent = fmtNum(feed?.meta?.totalItems);
+  const feedGeneratedAt = feed?.meta?.generatedAt || null;
+  el.feedMeta.textContent = `Generated: ${fmtDateTime(feedGeneratedAt)}`;
+
+  const latestRun = Array.isArray(semantic?.runs) ? semantic.runs[0] : null;
+  el.latestRunAt.textContent = latestRun?.fetchedAt ? fmtDateTime(latestRun.fetchedAt) : "n/a";
+  el.latestRunMeta.textContent = latestRun
+    ? `Run ${latestRun.runId || "unknown"} | ${latestRun.llmProvider || "n/a"}:${latestRun.llmModel || "n/a"}`
+    : "No semantic run data.";
+
+  el.llmSuccess.textContent = latestRun ? fmtPercent(latestRun.llmSuccessRate) : "n/a";
+  el.llmMeta.textContent = latestRun
+    ? `Attempts ${fmtNum(latestRun.llmAttempts)} | Failures ${fmtNum(latestRun.llmFailures)}`
+    : "No attempts recorded.";
+
+  renderComposition(diag);
+  renderSemanticRuns(semantic);
+  renderSemanticAgg(semantic);
+  renderDiagnosticsTables(diag);
+}
+
+async function loadDashboard() {
+  syncStateFromInputs();
+  el.refresh.disabled = true;
+  setStatus("Loading diagnostics...", "neutral");
+
+  const healthUrl = `${state.apiBase}/health`;
+  const feedUrl = `${state.apiBase}/feed?page=1&pageSize=1&sort=score&cache=0`;
+  const semanticUrl = `${state.apiBase}/admin/semantic-metrics?limit=${state.semanticLimit}`;
+  const diagnosticsUrl = `${state.apiBase}/admin/feed-diagnostics?topN=${state.topN}`;
+
+  const [healthResult, feedResult, semanticResult, diagResult] = await Promise.allSettled([
+    fetchJson(healthUrl, ""),
+    fetchJson(feedUrl, ""),
+    fetchJson(semanticUrl, state.adminToken),
+    fetchJson(diagnosticsUrl, state.adminToken),
+  ]);
+
+  const errors = [];
+  const health = healthResult.status === "fulfilled" ? healthResult.value : null;
+  const feed = feedResult.status === "fulfilled" ? feedResult.value : null;
+  const semantic = semanticResult.status === "fulfilled" ? semanticResult.value : null;
+  const diag = diagResult.status === "fulfilled" ? diagResult.value : null;
+
+  if (healthResult.status === "rejected") {
+    errors.push(`health: ${healthResult.reason instanceof Error ? healthResult.reason.message : String(healthResult.reason)}`);
+  }
+  if (feedResult.status === "rejected") {
+    errors.push(`feed: ${feedResult.reason instanceof Error ? feedResult.reason.message : String(feedResult.reason)}`);
+  }
+  if (semanticResult.status === "rejected") {
+    errors.push(
+      `semantic-metrics: ${semanticResult.reason instanceof Error ? semanticResult.reason.message : String(semanticResult.reason)}`
+    );
+  }
+  if (diagResult.status === "rejected") {
+    errors.push(
+      `feed-diagnostics: ${diagResult.reason instanceof Error ? diagResult.reason.message : String(diagResult.reason)}`
+    );
+  }
+
+  if (health || feed || semantic || diag) {
+    renderSummary(health, feed, semantic, diag);
+  }
+
+  if (errors.length === 0) {
+    setStatus(`Diagnostics updated at ${new Date().toLocaleTimeString()}.`, "ok");
+  } else if (errors.length < 4) {
+    setStatus(`Partial diagnostics loaded. ${errors.join(" | ")}`, "warn");
+  } else {
+    setStatus(`Diagnostics failed. ${errors.join(" | ")}`, "error");
+  }
+  el.refresh.disabled = false;
+}
+
+el.refresh.addEventListener("click", () => {
+  void loadDashboard();
+});
+
+el.adminToken.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    event.preventDefault();
+    void loadDashboard();
+  }
+});
+
+el.apiBase.addEventListener("change", () => {
+  syncStateFromInputs();
+});
+el.semanticLimit.addEventListener("change", () => {
+  syncStateFromInputs();
+});
+el.topN.addEventListener("change", () => {
+  syncStateFromInputs();
+});
+
+syncInputs();
+void loadDashboard();

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -15,6 +15,9 @@
           This feed is generated from active Polymarket markets and prioritizes policy, macro, geopolitics, and public
           impact.
         </p>
+        <p class="hero-links">
+          <a class="admin-link" href="/admin.html">Open Admin Diagnostics</a>
+        </p>
       </header>
 
       <section class="controls">

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -349,6 +349,155 @@ body {
   gap: 12px;
 }
 
+.hero-links {
+  margin-top: 12px;
+  margin-bottom: 0;
+}
+
+.admin-link {
+  color: var(--link);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.admin-link:hover {
+  text-decoration: underline;
+}
+
+.admin-shell {
+  max-width: 1240px;
+}
+
+.admin-hero h1 {
+  font-size: clamp(28px, 4.2vw, 46px);
+}
+
+.admin-controls {
+  grid-template-columns: minmax(220px, 2fr) minmax(220px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) auto;
+}
+
+.dashboard-status {
+  margin-top: 16px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  background: #fffaf0;
+}
+
+.status-ok {
+  border-color: #5f8b52;
+  background: #eff7e9;
+  color: #214018;
+}
+
+.status-warn {
+  border-color: #c39f57;
+  background: #fff7e4;
+  color: #624b18;
+}
+
+.status-error {
+  border-color: #b25b56;
+  background: #fff0ef;
+  color: #5e1d1a;
+}
+
+.dashboard-grid {
+  margin-top: 16px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.metric-card {
+  min-height: 140px;
+}
+
+.metric-card h3 {
+  margin: 0;
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.metric-value {
+  margin-top: 12px;
+  font-family: "Palatino Linotype", "Book Antiqua", "Times New Roman", serif;
+  font-size: clamp(25px, 2.8vw, 34px);
+  line-height: 1.1;
+}
+
+.metric-sub {
+  margin-top: 8px;
+  margin-bottom: 0;
+  color: #4e4538;
+  font-size: 13px;
+}
+
+.panel {
+  margin-top: 12px;
+}
+
+.panel h2 {
+  margin-top: 0;
+  margin-bottom: 4px;
+  font-size: 24px;
+}
+
+.panel-sub {
+  margin-top: 0;
+  color: #4e4538;
+}
+
+.panel-note {
+  margin: 8px 0 10px;
+  font-weight: 600;
+  color: #2a281f;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.diag-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.diag-table th,
+.diag-table td {
+  border-bottom: 1px solid #dfcfb1;
+  text-align: left;
+  padding: 8px 10px;
+  vertical-align: top;
+}
+
+.diag-table th {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: #4e4538;
+  background: #f8f1df;
+}
+
+.table-empty {
+  margin: 6px 0;
+  color: #5b5449;
+}
+
+.split-panels {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.split-panels h3 {
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-size: 16px;
+}
+
 @media (max-width: 980px) {
   .story-card {
     grid-column: span 12;
@@ -364,6 +513,14 @@ body {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .admin-controls {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .dashboard-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .hero h1 {
     font-size: clamp(28px, 7vw, 46px);
   }
@@ -371,6 +528,10 @@ body {
 
 @media (max-width: 560px) {
   .controls {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-controls {
     grid-template-columns: 1fr;
   }
 
@@ -384,5 +545,13 @@ body {
 
   .card h3 {
     font-size: 20px;
+  }
+
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .split-panels {
+    grid-template-columns: 1fr;
   }
 }

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -494,6 +494,35 @@ This file is the explicit handoff checkpoint.
 123. Post-rollout monitor confirmation:
    - production monitor `22254553101` success.
    - staging monitor `22254553099` success.
+124. Started `MILESTONE-DASHBOARD-012` on branch `agent/dashboard-pass1`.
+125. Added read-only admin dashboard page:
+   - new route file: `apps/web/public/admin.html`.
+   - dashboard presents operational cards/panels for:
+     - service health + feed size
+     - semantic telemetry runs/aggregates
+     - taxonomy composition
+     - top-decision diagnostics.
+126. Added dashboard client logic:
+   - new script: `apps/web/public/admin.js`.
+   - reads existing endpoints only:
+     - `/api/health`
+     - `/api/feed`
+     - `/api/admin/semantic-metrics`
+     - `/api/admin/feed-diagnostics`
+   - supports admin token input (`X-Admin-Token`) for protected admin APIs.
+127. Added dashboard styling and navigation:
+   - extended `apps/web/public/styles.css` with diagnostics table/panel styles.
+   - added feed-page link to admin dashboard in `apps/web/public/index.html`.
+128. Added dashboard docs:
+   - `apps/web/README.md` now includes `/admin.html` usage + endpoint/token behavior.
+   - root `README.md` now includes production diagnostics URL.
+129. Milestone bookkeeping updates:
+   - `docs/ROADMAP_QUEUE.md` marks `MILESTONE-DASHBOARD-012` complete.
+   - `docs/POST_V2_BACKLOG.md` moves `MILESTONE-DASHBOARD-012` into recently completed.
+   - `docs/ISSUE_CHECKLIST.md` adds `QA-013` completed.
+130. Validation (local):
+   - `node --check apps/web/public/admin.js` passed.
+   - `npm run check` passed after dashboard implementation.
 
 ## How to start a fresh Codex session
 1. Open terminal in repo: `E:\Coasensus Predictive future`

--- a/docs/ISSUE_CHECKLIST.md
+++ b/docs/ISSUE_CHECKLIST.md
@@ -50,6 +50,7 @@
 - [x] `QA-010` Add automated 24h launch-stability readiness checker for monitor workflows
 - [x] `QA-011` Add top-N category dominance diagnostics + monitor alert signal
 - [x] `QA-012` Add daily editorial top-20 snapshot workflow and reviewer decision log path
+- [x] `QA-013` Add read-only admin diagnostics dashboard view backed by existing admin APIs
 
 ## EPIC-06 Hybrid Semantic Layer (Execution Plan V2)
 - [x] `SEM-001` Add phase-1 bouncer prefilter (query + local gates)

--- a/docs/POST_V2_BACKLOG.md
+++ b/docs/POST_V2_BACKLOG.md
@@ -4,17 +4,7 @@ This backlog starts after `MILESTONE-PERF-008` completion and focuses on launch 
 
 ## Active
 
-### `MILESTONE-DASHBOARD-012`
-- Goal: make diagnostics more accessible than raw API responses.
-- Scope:
-  - Create read-only admin dashboard view for key metrics:
-    - feed freshness
-    - semantic success/failure
-    - taxonomy distribution
-    - cache status
-- Acceptance:
-  - Dashboard loads from existing admin endpoints with token auth.
-  - No write actions; diagnostics-only surface.
+- (none)
 
 ## Recently Completed
 
@@ -45,6 +35,18 @@ This backlog starts after `MILESTONE-PERF-008` completion and focuses on launch 
 - Acceptance:
   - Daily snapshots are generated and inspectable.
   - Review records can be attached to launch/no-go decisions.
+
+### `MILESTONE-DASHBOARD-012`
+- Goal: make diagnostics more accessible than raw API responses.
+- Scope:
+  - Create read-only admin dashboard view for key metrics:
+    - feed freshness
+    - semantic success/failure
+    - taxonomy distribution
+    - cache status
+- Acceptance:
+  - Dashboard loads from existing admin endpoints with token auth.
+  - No write actions; diagnostics-only surface.
 
 ## Parking Lot (Promote Only When Needed)
 

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -765,3 +765,28 @@
 268. Post-rollout monitor verification:
    - Monitor Production `22254553101` => success.
    - Monitor Staging `22254553099` => success.
+269. Started `MILESTONE-DASHBOARD-012` on branch `agent/dashboard-pass1`.
+270. Added read-only diagnostics dashboard page:
+   - new frontend route asset: `apps/web/public/admin.html`.
+   - dashboard includes panels for health/feed status, semantic telemetry, taxonomy distribution, and decision diagnostics.
+271. Added diagnostics dashboard data client:
+   - new script: `apps/web/public/admin.js`.
+   - fetches existing endpoints only:
+     - `/api/health`
+     - `/api/feed`
+     - `/api/admin/semantic-metrics`
+     - `/api/admin/feed-diagnostics`
+   - applies `X-Admin-Token` for protected admin endpoints.
+272. Added dashboard UI integration:
+   - updated `apps/web/public/styles.css` with dashboard layout/table/status styling.
+   - added feed-page link to diagnostics dashboard in `apps/web/public/index.html`.
+273. Updated docs for dashboard usage:
+   - `apps/web/README.md` now documents `/admin.html` and token behavior.
+   - root `README.md` now references production diagnostics URL.
+274. Milestone bookkeeping synced:
+   - `docs/ROADMAP_QUEUE.md` marks `MILESTONE-DASHBOARD-012` complete.
+   - `docs/POST_V2_BACKLOG.md` moves dashboard milestone to recently completed.
+   - `docs/ISSUE_CHECKLIST.md` adds `QA-013` completed.
+275. Validation:
+   - `node --check apps/web/public/admin.js` => success.
+   - `npm run check` => success after dashboard implementation.

--- a/docs/ROADMAP_QUEUE.md
+++ b/docs/ROADMAP_QUEUE.md
@@ -21,7 +21,7 @@ Lightweight tracker to keep momentum high while preserving deferred work.
 - [x] `MILESTONE-LAUNCH-STABILITY-009` Automate 24h launch-stability gate tracking (monitor pass window + readiness status).
 - [x] `MILESTONE-CATEGORY-SANITY-010` Add automated category-dominance checks for top feed cards.
 - [x] `MILESTONE-EDITORIAL-SPOTCHECK-011` Add top-20 feed snapshot + reviewer log workflow.
-- [ ] `MILESTONE-DASHBOARD-012` Add lightweight admin diagnostics dashboard view (read-only).
+- [x] `MILESTONE-DASHBOARD-012` Add lightweight admin diagnostics dashboard view (read-only).
 
 ## Next
 


### PR DESCRIPTION
## Summary\n- add /admin.html diagnostics dashboard page\n- add dmin.js client to query existing diagnostics endpoints with admin token header\n- add dashboard styling and link from feed homepage\n- update queue/checklist/backlog/handoff/progress docs for MILESTONE-DASHBOARD-012\n\n## Validation\n- node --check apps/web/public/admin.js\n- npm run check\n