### PR TITLE
test: add ranking regression suite for feed ordering

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -565,6 +565,17 @@ This file is the explicit handoff checkpoint.
 143. Local validation status:
    - `npm run check` passed.
    - `npx wrangler deploy --dry-run --config infra/cloudflare/wrangler.api.ci.jsonc --env staging` passed.
+144. Started `MILESTONE-RANKING-TESTS-015` on branch `agent/ranking-tests-pass1`.
+145. Added dedicated ranking regression suite in `services/ingest-worker/src/ranking-regression.test.ts`:
+   - deterministic tie-breaks for equal-score/equal-volume/equal-liquidity/equal-endDate cases
+   - null-metric ordering expectations
+   - page clamp behavior when requested page exceeds total pages
+   - expanded query category parsing coverage (`tech_ai`, `sports`, `entertainment`).
+146. Hardened local feed sorter determinism in `services/ingest-worker/src/feed-store.ts`:
+   - all sort modes now use `id` tie-break fallback
+   - category parser now includes all expanded categories used across the stack.
+147. Validation status for ranking milestone:
+   - `npm run check` passed with new ranking suite included in CI-equivalent run.
 
 ## How to start a fresh Codex session
 1. Open terminal in repo: `E:\Coasensus Predictive future`

--- a/docs/ISSUE_CHECKLIST.md
+++ b/docs/ISSUE_CHECKLIST.md
@@ -52,6 +52,7 @@
 - [x] `QA-012` Add daily editorial top-20 snapshot workflow and reviewer decision log path
 - [x] `QA-013` Add read-only admin diagnostics dashboard view backed by existing admin APIs
 - [x] `QA-014` Add automatic semantic failover cooldown after consecutive LLM-failure runs
+- [x] `QA-015` Add ranking regression tests for deterministic ordering and edge-case pagination
 
 ## EPIC-06 Hybrid Semantic Layer (Execution Plan V2)
 - [x] `SEM-001` Add phase-1 bouncer prefilter (query + local gates)

--- a/docs/POST_V2_BACKLOG.md
+++ b/docs/POST_V2_BACKLOG.md
@@ -8,6 +8,16 @@ This backlog starts after `MILESTONE-PERF-008` completion and focuses on launch 
 
 ## Recently Completed
 
+### `MILESTONE-RANKING-TESTS-015`
+- Goal: prevent silent ranking regressions and unstable ordering behavior.
+- Scope:
+  - Add dedicated ranking regression suite for local feed sorting paths.
+  - Lock deterministic tie-break rules for equal-score/equal-metric cases.
+  - Cover edge cases for null metrics and out-of-range pagination.
+- Acceptance:
+  - CI runs ranking tests and fails on ordering regressions.
+  - Sorting behavior is deterministic for ties (`id` fallback).
+
 ### `MILESTONE-SEMANTIC-FAILOVER-013`
 - Goal: keep refresh pipeline resilient when LLM providers degrade temporarily.
 - Scope:
@@ -61,4 +71,3 @@ This backlog starts after `MILESTONE-PERF-008` completion and focuses on launch 
 ## Parking Lot (Promote Only When Needed)
 
 - `MILESTONE-UI-POLISH-014`: masonry layout, richer news card anatomy, optional iconography.
-- `MILESTONE-RANKING-TESTS-015`: dedicated ranking regression/edge-case test suite.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -851,3 +851,16 @@
 293. Validation:
    - `npm run check` => success.
    - `npx wrangler deploy --dry-run --config infra/cloudflare/wrangler.api.ci.jsonc --env staging` => success.
+294. Started `MILESTONE-RANKING-TESTS-015` on branch `agent/ranking-tests-pass1`.
+295. Added dedicated ranking regression suite:
+   - new file: `services/ingest-worker/src/ranking-regression.test.ts`.
+   - coverage includes:
+     - deterministic tie-break ordering for `score`, `volume`, `liquidity`, and `endDate` sort modes
+     - null-value ordering behavior (`null` volume/liquidity/endDate)
+     - pagination clamp behavior when requested page exceeds total pages
+     - expanded category query parsing (`tech_ai`, `sports`, `entertainment`).
+296. Hardened feed sorting determinism in `services/ingest-worker/src/feed-store.ts`:
+   - added `id` tie-break fallback across all sort modes.
+   - updated local category set to include `tech_ai`, `sports`, and `entertainment` for query parity.
+297. Validation:
+   - `npm run check` => success (`services/ingest-worker` now runs 20 tests including ranking regression suite).

--- a/docs/ROADMAP_QUEUE.md
+++ b/docs/ROADMAP_QUEUE.md
@@ -23,6 +23,7 @@ Lightweight tracker to keep momentum high while preserving deferred work.
 - [x] `MILESTONE-EDITORIAL-SPOTCHECK-011` Add top-20 feed snapshot + reviewer log workflow.
 - [x] `MILESTONE-DASHBOARD-012` Add lightweight admin diagnostics dashboard view (read-only).
 - [x] `MILESTONE-SEMANTIC-FAILOVER-013` Add temporary heuristic-only cooldown after consecutive LLM failure runs.
+- [x] `MILESTONE-RANKING-TESTS-015` Add dedicated ranking regression/edge-case test suite.
 
 ## Next
 

--- a/services/ingest-worker/src/feed-store.ts
+++ b/services/ingest-worker/src/feed-store.ts
@@ -16,6 +16,9 @@ const CATEGORY_SET = new Set<MarketCategory>([
   "geopolitics",
   "public_health",
   "climate_energy",
+  "tech_ai",
+  "sports",
+  "entertainment",
   "other",
 ]);
 
@@ -59,6 +62,10 @@ function scoreValue(item: CuratedFeedItem): number {
   return item.score.civicScore + item.score.newsworthinessScore;
 }
 
+function tieBreakById(a: CuratedFeedItem, b: CuratedFeedItem): number {
+  return a.id.localeCompare(b.id);
+}
+
 function dateValue(item: CuratedFeedItem): number {
   if (!item.endDate) {
     return Number.POSITIVE_INFINITY;
@@ -71,20 +78,20 @@ function sortItems(items: CuratedFeedItem[], sort: FeedSort): CuratedFeedItem[] 
   const copy = [...items];
 
   if (sort === "volume") {
-    copy.sort((a, b) => (b.volume ?? -1) - (a.volume ?? -1));
+    copy.sort((a, b) => (b.volume ?? -1) - (a.volume ?? -1) || tieBreakById(a, b));
     return copy;
   }
   if (sort === "liquidity") {
-    copy.sort((a, b) => (b.liquidity ?? -1) - (a.liquidity ?? -1));
+    copy.sort((a, b) => (b.liquidity ?? -1) - (a.liquidity ?? -1) || tieBreakById(a, b));
     return copy;
   }
   if (sort === "endDate") {
-    copy.sort((a, b) => dateValue(a) - dateValue(b));
+    copy.sort((a, b) => dateValue(a) - dateValue(b) || tieBreakById(a, b));
     return copy;
   }
 
   // score sort is default for relevance.
-  copy.sort((a, b) => scoreValue(b) - scoreValue(a));
+  copy.sort((a, b) => scoreValue(b) - scoreValue(a) || tieBreakById(a, b));
   return copy;
 }
 

--- a/services/ingest-worker/src/ranking-regression.test.ts
+++ b/services/ingest-worker/src/ranking-regression.test.ts
@@ -1,0 +1,144 @@
+import type { Market, MarketCategory } from "@coasensus/shared-types";
+import { describe, expect, it } from "vitest";
+import { buildFeedFromMarkets, normalizeFeedQuery } from "./feed-store.js";
+
+function mk(
+  id: string,
+  overrides: Partial<Market> = {}
+): Market {
+  return {
+    id,
+    question: "Will senate pass the budget bill?",
+    description: "",
+    url: `https://polymarket.com/event/${id}`,
+    endDate: null,
+    liquidity: 12_000,
+    volume: 30_000,
+    openInterest: 5_000,
+    tags: ["policy"],
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+function ids(markets: Array<{ id: string }>): string[] {
+  return markets.map((item) => item.id);
+}
+
+describe("ranking regression suite", () => {
+  it("accepts expanded category filters in query parsing", () => {
+    const categories: MarketCategory[] = ["tech_ai", "sports", "entertainment"];
+    for (const category of categories) {
+      const query = normalizeFeedQuery(new URLSearchParams(`category=${category}`));
+      expect(query.category).toBe(category);
+    }
+  });
+
+  it("uses deterministic id tie-break for score sort", () => {
+    const markets: Market[] = [mk("c"), mk("a"), mk("b")];
+    const feed = buildFeedFromMarkets(
+      markets,
+      {
+        page: 1,
+        pageSize: 20,
+        sort: "score",
+        includeRejected: true,
+      },
+      "ranking-regression"
+    );
+
+    expect(ids(feed.items)).toEqual(["a", "b", "c"]);
+  });
+
+  it("uses deterministic id tie-break for volume sort, with null values last", () => {
+    const markets: Market[] = [
+      mk("c", { volume: 100_000 }),
+      mk("a", { volume: 100_000 }),
+      mk("b", { volume: 90_000 }),
+      mk("d", { volume: null }),
+    ];
+
+    const feed = buildFeedFromMarkets(
+      markets,
+      {
+        page: 1,
+        pageSize: 20,
+        sort: "volume",
+        includeRejected: true,
+      },
+      "ranking-regression"
+    );
+
+    expect(ids(feed.items)).toEqual(["a", "c", "b", "d"]);
+  });
+
+  it("uses deterministic id tie-break for liquidity sort, with null values last", () => {
+    const markets: Market[] = [
+      mk("c", { liquidity: 25_000 }),
+      mk("a", { liquidity: 25_000 }),
+      mk("b", { liquidity: 20_000 }),
+      mk("d", { liquidity: null }),
+    ];
+
+    const feed = buildFeedFromMarkets(
+      markets,
+      {
+        page: 1,
+        pageSize: 20,
+        sort: "liquidity",
+        includeRejected: true,
+      },
+      "ranking-regression"
+    );
+
+    expect(ids(feed.items)).toEqual(["a", "c", "b", "d"]);
+  });
+
+  it("sorts endDate ascending, applies id tie-break, and places null endDate last", () => {
+    const markets: Market[] = [
+      mk("b", { endDate: "2026-01-02T00:00:00Z" }),
+      mk("a", { endDate: "2026-01-02T00:00:00Z" }),
+      mk("c", { endDate: "2026-02-01T00:00:00Z" }),
+      mk("d", { endDate: null }),
+    ];
+
+    const feed = buildFeedFromMarkets(
+      markets,
+      {
+        page: 1,
+        pageSize: 20,
+        sort: "endDate",
+        includeRejected: true,
+      },
+      "ranking-regression"
+    );
+
+    expect(ids(feed.items)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("clamps page to totalPages while preserving ranking order", () => {
+    const markets: Market[] = [
+      mk("a", { volume: 120_000 }),
+      mk("b", { volume: 110_000 }),
+      mk("c", { volume: 100_000 }),
+      mk("d", { volume: 90_000 }),
+    ];
+
+    const feed = buildFeedFromMarkets(
+      markets,
+      {
+        page: 99,
+        pageSize: 2,
+        sort: "volume",
+        includeRejected: true,
+      },
+      "ranking-regression"
+    );
+
+    expect(feed.meta.totalPages).toBe(2);
+    expect(feed.meta.page).toBe(2);
+    expect(ids(feed.items)).toEqual(["c", "d"]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add dedicated ranking regression suite at services/ingest-worker/src/ranking-regression.test.ts
- enforce deterministic id tie-break fallback for score/volume/liquidity/endDate sorting in eed-store.ts
- expand local feed category parser parity to include 	ech_ai, sports, and entertainment
- update backlog/queue/checkpoint docs for MILESTONE-RANKING-TESTS-015

## Validation
- 
pm run check
