### PR TITLE
MILESTONE-SMART-FIREHOSE-016 (pass 1): websocket foundation + fallback

### DIFF
--- a/docs/POST_V2_BACKLOG.md
+++ b/docs/POST_V2_BACKLOG.md
@@ -4,7 +4,14 @@ This backlog starts after `MILESTONE-PERF-008` completion and focuses on launch 
 
 ## Active
 
-- (none)
+### `MILESTONE-SMART-FIREHOSE-016` (Foundation Pass 1)
+- Goal: shift ingest toward incremental market updates while preserving reliability.
+- Scope:
+  - Add a managed Polymarket market-channel WebSocket client with reconnect/backoff.
+  - Maintain in-memory snapshot updated by socket messages.
+  - Add staleness-aware REST fallback so ingest remains deterministic during socket gaps.
+- Current status:
+  - foundation implemented in `services/ingest-worker`; production Worker integration still pending follow-up.
 
 ## Recently Completed
 

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -879,3 +879,37 @@
      - `docs/POST_V2_BACKLOG.md`.
    - `node --check apps/web/public/app.js` => success.
    - `npm run check` => success.
+302. Started `MILESTONE-SMART-FIREHOSE-016` on branch `agent/smart-firehose-foundation-pass1`.
+303. Added Smart Firehose foundation module:
+   - new file: `services/ingest-worker/src/polymarket-firehose.ts`.
+   - capabilities:
+     - managed Polymarket market-channel WebSocket client
+     - reconnect with exponential backoff
+     - in-memory market snapshot + freshness checks
+     - staleness-aware REST fallback (`fetchForIngestion`) to preserve deterministic ingest runs.
+304. Wired ingestion runner to optionally consume firehose snapshot:
+   - `services/ingest-worker/src/index.ts` now supports:
+     - `RunIngestionOptions.firehoseClient`
+     - `RunIngestionOptions.firehoseMaxStalenessMs`
+     - snapshot source tracking (`firehose_snapshot` vs `rest_fallback`).
+   - smoke runner now supports firehose env flags in `services/ingest-worker/src/smoke.ts`:
+     - `INGEST_USE_SMART_FIREHOSE`
+     - `INGEST_FIREHOSE_WS_URL`
+     - `INGEST_FIREHOSE_STALENESS_MS`
+     - `INGEST_FIREHOSE_RECONNECT_BASE_MS`
+     - `INGEST_FIREHOSE_RECONNECT_MAX_MS`
+     - `INGEST_FIREHOSE_WARMUP_MS`
+     - `INGEST_FIREHOSE_SUBSCRIPTION_JSON`.
+305. Added regression coverage for Smart Firehose:
+   - new test file: `services/ingest-worker/src/polymarket-firehose.test.ts`.
+   - coverage includes:
+     - nested market-message parsing
+     - fresh snapshot usage without REST calls
+     - stale snapshot REST fallback
+     - websocket-applied price updates
+     - reconnect scheduling on socket close.
+306. Validation:
+   - `npm -C services/ingest-worker run typecheck` => success.
+   - `npm -C services/ingest-worker run lint` => success.
+   - `npm -C services/ingest-worker run test` => success (25 tests).
+   - `npm run check` => success (repo-wide).

--- a/docs/ROADMAP_QUEUE.md
+++ b/docs/ROADMAP_QUEUE.md
@@ -10,6 +10,7 @@ Lightweight tracker to keep momentum high while preserving deferred work.
 
 ## Now
 
+- [ ] `MILESTONE-SMART-FIREHOSE-016` Smart Firehose foundation (WebSocket market stream client + reconnect/fallback in ingest worker).
 - [x] `MILESTONE-DEDUP-001` Topic/event de-dup in feed curation (reduce same-story dominance)
 - [x] `MILESTONE-UI-SEARCH-002` Add text search (question/description) on API + web controls.
 - [x] `MILESTONE-REGION-003` Add region filter controls and expose geo tag in UI.

--- a/services/ingest-worker/README.md
+++ b/services/ingest-worker/README.md
@@ -35,6 +35,17 @@ Storage mode options:
 - `INGEST_PERSIST_SQLITE` (default: `1`)
 - `INGEST_SQLITE_DB_PATH` (default: `infra/db/coasensus.sqlite`)
 
+Smart Firehose (foundation pass):
+- `INGEST_USE_SMART_FIREHOSE` (default: `0`; set `1` to enable market-channel client)
+- `INGEST_FIREHOSE_WS_URL` (default: `wss://ws-subscriptions-clob.polymarket.com/ws/market`)
+- `INGEST_FIREHOSE_STALENESS_MS` (default: `90000`)
+- `INGEST_FIREHOSE_RECONNECT_BASE_MS` (default: `800`)
+- `INGEST_FIREHOSE_RECONNECT_MAX_MS` (default: `15000`)
+- `INGEST_FIREHOSE_WARMUP_MS` (default: `4000`)
+- `INGEST_FIREHOSE_SUBSCRIPTION_JSON` (optional JSON object to send on socket open)
+
+When Smart Firehose is enabled, ingestion uses websocket snapshot data if it is fresh; otherwise it falls back to REST fetch automatically.
+
 ## Persistence outputs
 Each persisted run writes:
 - `infra/db/local/snapshots/<run-id>.json`

--- a/services/ingest-worker/src/polymarket-firehose.test.ts
+++ b/services/ingest-worker/src/polymarket-firehose.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  SmartFirehoseClient,
+  extractMarketUpdatesFromPayload,
+  type WebSocketLike,
+} from "./polymarket-firehose.js";
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+class FakeSocket implements WebSocketLike {
+  private readonly listeners = new Map<string, Array<(event: unknown) => void>>();
+
+  addEventListener(name: "open" | "message" | "close" | "error", listener: (event: unknown) => void): void {
+    const list = this.listeners.get(name) ?? [];
+    list.push(listener);
+    this.listeners.set(name, list);
+  }
+
+  removeEventListener(name: "open" | "message" | "close" | "error", listener: (event: unknown) => void): void {
+    const list = this.listeners.get(name) ?? [];
+    this.listeners.set(
+      name,
+      list.filter((item) => item !== listener)
+    );
+  }
+
+  send(data: string): void {
+    void data;
+    // noop for tests
+  }
+
+  close(code?: number, reason?: string): void {
+    void code;
+    void reason;
+    this.emit("close", {});
+  }
+
+  emit(name: "open" | "message" | "close" | "error", event: unknown): void {
+    for (const listener of this.listeners.get(name) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("extractMarketUpdatesFromPayload", () => {
+  it("extracts updates from nested payloads and ignores ambiguous ids", () => {
+    const updates = extractMarketUpdatesFromPayload({
+      type: "market",
+      events: [
+        { market: "m1", price: "0.77" },
+        { nested: { market_id: "m2", best_bid: "0.42", best_ask: "0.44" } },
+        { id: "should-ignore-without-price" },
+        { id: "m3", price: 0.33 },
+      ],
+    });
+
+    const byId = new Map(updates.map((item) => [item.marketId, item]));
+    expect(byId.get("m1")).toMatchObject({ lastTradePrice: 0.77, bestBid: null, bestAsk: null });
+    expect(byId.get("m2")).toMatchObject({ lastTradePrice: null, bestBid: 0.42, bestAsk: 0.44 });
+    expect(byId.get("m3")).toMatchObject({ lastTradePrice: 0.33, bestBid: null, bestAsk: null });
+    expect(byId.has("should-ignore-without-price")).toBe(false);
+  });
+});
+
+describe("SmartFirehoseClient", () => {
+  it("uses a fresh firehose snapshot without REST fallback", async () => {
+    let nowMs = 100;
+    const bootstrapFetch = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      jsonResponse([{ id: "1", question: "Q1", price: 0.1 }])
+    );
+    const fallbackFetch = vi.fn<typeof fetch>();
+
+    const client = new SmartFirehoseClient({
+      now: () => nowMs,
+      logger: noopLogger,
+    });
+
+    await client.bootstrap({
+      fetchImpl: bootstrapFetch,
+      limitPerPage: 50,
+      maxPages: 1,
+      retryBackoffMs: 0,
+    });
+
+    nowMs = 1_000;
+    const result = await client.fetchForIngestion(
+      {
+        fetchImpl: fallbackFetch,
+        limitPerPage: 50,
+        maxPages: 1,
+        retryBackoffMs: 0,
+      },
+      5_000
+    );
+
+    expect(result.source).toBe("firehose_snapshot");
+    expect(result.pagesFetched).toBe(0);
+    expect(result.markets.map((market) => market.id)).toEqual(["1"]);
+    expect(fallbackFetch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to REST when snapshot is stale", async () => {
+    let nowMs = 100;
+    const bootstrapFetch = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      jsonResponse([{ id: "1", question: "Q1", price: 0.1 }])
+    );
+    const fallbackFetch = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      jsonResponse([{ id: "2", question: "Q2", price: 0.2 }])
+    );
+
+    const client = new SmartFirehoseClient({
+      now: () => nowMs,
+      logger: noopLogger,
+    });
+
+    await client.bootstrap({
+      fetchImpl: bootstrapFetch,
+      limitPerPage: 50,
+      maxPages: 1,
+      retryBackoffMs: 0,
+    });
+
+    nowMs = 90_000;
+    const result = await client.fetchForIngestion(
+      {
+        fetchImpl: fallbackFetch,
+        limitPerPage: 50,
+        maxPages: 1,
+        retryBackoffMs: 0,
+      },
+      2_000
+    );
+
+    expect(result.source).toBe("rest_fallback");
+    expect(result.markets.map((market) => market.id)).toEqual(["2"]);
+    expect(fallbackFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies websocket price updates to the existing snapshot", async () => {
+    let nowMs = 0;
+    const socket = new FakeSocket();
+    const bootstrapFetch = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      jsonResponse([{ id: "101", question: "Q101", price: 0.2, lastTradePrice: 0.2 }])
+    );
+
+    const client = new SmartFirehoseClient({
+      now: () => nowMs,
+      connectImpl: () => socket,
+      logger: noopLogger,
+    });
+
+    await client.bootstrap({
+      fetchImpl: bootstrapFetch,
+      limitPerPage: 50,
+      maxPages: 1,
+      retryBackoffMs: 0,
+    });
+    client.start();
+
+    socket.emit("open", {});
+    nowMs = 2_000;
+    socket.emit("message", {
+      data: JSON.stringify({
+        channel: "market",
+        market: "101",
+        price: 0.73,
+      }),
+    });
+
+    const snapshot = client.getSnapshot(60_000);
+    const market = snapshot.markets.find((item) => String(item.id ?? item.marketId) === "101");
+    expect(snapshot.source).toBe("websocket");
+    expect(snapshot.stats.updatesApplied).toBeGreaterThanOrEqual(1);
+    expect(market?.lastTradePrice).toBe(0.73);
+    expect(market?.price).toBe(0.73);
+
+    client.stop();
+  });
+
+  it("reconnects with backoff after socket close", () => {
+    vi.useFakeTimers();
+
+    const socketOne = new FakeSocket();
+    const socketTwo = new FakeSocket();
+    const sockets = [socketOne, socketTwo];
+    const connectImpl = vi.fn(() => sockets.shift() ?? new FakeSocket());
+
+    const client = new SmartFirehoseClient({
+      connectImpl,
+      reconnectBaseMs: 50,
+      reconnectMaxMs: 500,
+      logger: noopLogger,
+    });
+
+    client.start();
+    expect(connectImpl).toHaveBeenCalledTimes(1);
+
+    socketOne.emit("close", {});
+    vi.advanceTimersByTime(49);
+    expect(connectImpl).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(1);
+    expect(connectImpl).toHaveBeenCalledTimes(2);
+
+    client.stop();
+  });
+});

--- a/services/ingest-worker/src/polymarket-firehose.ts
+++ b/services/ingest-worker/src/polymarket-firehose.ts
@@ -1,0 +1,502 @@
+import { logInfo, logWarn } from "./logger.js";
+import {
+  fetchActiveMarkets,
+  type ActiveMarketsFetchResult,
+  type PolymarketFetchOptions,
+} from "./polymarket-client.js";
+import type { RawPolymarketMarket } from "./normalize.js";
+
+export const DEFAULT_POLYMARKET_MARKET_WS_URL = "wss://ws-subscriptions-clob.polymarket.com/ws/market";
+const DEFAULT_SNAPSHOT_MAX_STALENESS_MS = 90_000;
+const DEFAULT_RECONNECT_BASE_MS = 800;
+const DEFAULT_RECONNECT_MAX_MS = 15_000;
+
+const MARKET_ID_PRIMARY_KEYS = ["market", "market_id", "marketId", "condition_id", "conditionId", "token_id", "tokenId"];
+const MARKET_ID_FALLBACK_KEYS = ["id"];
+const LAST_TRADE_PRICE_KEYS = ["last_trade_price", "lastTradePrice", "price", "p"];
+const BEST_BID_KEYS = ["best_bid", "bestBid", "bid"];
+const BEST_ASK_KEYS = ["best_ask", "bestAsk", "ask"];
+
+type ListenerName = "open" | "message" | "close" | "error";
+
+export type FirehoseIngestionSource = "firehose_snapshot" | "rest_fallback";
+
+export interface FirehoseStats {
+  messages: number;
+  parseFailures: number;
+  updatesApplied: number;
+  unknownMarketUpdates: number;
+  reconnects: number;
+  restBootstraps: number;
+  restFallbacks: number;
+}
+
+export interface FirehoseSnapshot {
+  source: "none" | "rest_bootstrap" | "websocket";
+  updatedAt: string | null;
+  updatedAtMs: number;
+  marketCount: number;
+  isFresh: boolean;
+  wsConnected: boolean;
+  markets: RawPolymarketMarket[];
+  stats: FirehoseStats;
+}
+
+export interface FirehoseFetchResult extends ActiveMarketsFetchResult {
+  source: FirehoseIngestionSource;
+}
+
+export interface MarketChannelUpdate {
+  marketId: string;
+  lastTradePrice: number | null;
+  bestBid: number | null;
+  bestAsk: number | null;
+}
+
+export interface WebSocketLike {
+  addEventListener(name: ListenerName, listener: (event: unknown) => void): void;
+  removeEventListener(name: ListenerName, listener: (event: unknown) => void): void;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+}
+
+export type WebSocketFactory = (url: string) => WebSocketLike;
+
+export interface SmartFirehoseLogger {
+  info(event: string, details?: Record<string, unknown>): void;
+  warn(event: string, details?: Record<string, unknown>): void;
+}
+
+export interface SmartFirehoseOptions {
+  websocketUrl?: string;
+  subscriptionMessage?: Record<string, unknown> | null;
+  snapshotMaxStalenessMs?: number;
+  reconnectBaseMs?: number;
+  reconnectMaxMs?: number;
+  connectImpl?: WebSocketFactory;
+  now?: () => number;
+  logger?: SmartFirehoseLogger;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asNumberOrNull(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function asStringId(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const normalized = String(value).trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function toIsoDate(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+function deepCollectRecords(input: unknown, maxDepth = 6): Record<string, unknown>[] {
+  const collected: Record<string, unknown>[] = [];
+  const seen = new Set<object>();
+
+  function walk(value: unknown, depth: number): void {
+    if (depth > maxDepth || value === null || value === undefined) {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        walk(item, depth + 1);
+      }
+      return;
+    }
+
+    const record = asRecord(value);
+    if (!record) {
+      return;
+    }
+
+    if (seen.has(record)) {
+      return;
+    }
+    seen.add(record);
+    collected.push(record);
+
+    for (const nested of Object.values(record)) {
+      walk(nested, depth + 1);
+    }
+  }
+
+  walk(input, 0);
+  return collected;
+}
+
+function pickFirstString(record: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = asStringId(record[key]);
+    if (value) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function pickFirstNumber(record: Record<string, unknown>, keys: string[]): number | null {
+  for (const key of keys) {
+    const value = asNumberOrNull(record[key]);
+    if (value !== null) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function messageEventToText(event: unknown): string | null {
+  const maybeEvent = asRecord(event);
+  const payload = maybeEvent && "data" in maybeEvent ? maybeEvent.data : event;
+
+  if (typeof payload === "string") {
+    return payload;
+  }
+  if (payload instanceof ArrayBuffer) {
+    return new TextDecoder().decode(payload);
+  }
+  if (payload instanceof Uint8Array) {
+    return new TextDecoder().decode(payload);
+  }
+  if (payload && typeof payload === "object" && "toString" in payload) {
+    const maybeString = String(payload);
+    return maybeString.length > 0 ? maybeString : null;
+  }
+  return null;
+}
+
+function defaultWebSocketFactory(url: string): WebSocketLike {
+  const ctor = (globalThis as { WebSocket?: new (input: string) => WebSocketLike }).WebSocket;
+  if (!ctor) {
+    throw new Error("WebSocket is unavailable in this runtime");
+  }
+  return new ctor(url);
+}
+
+function computeReconnectDelay(attempt: number, baseMs: number, maxMs: number): number {
+  const exponent = Math.max(0, attempt - 1);
+  const raw = baseMs * 2 ** exponent;
+  return Math.min(maxMs, raw);
+}
+
+export function extractMarketUpdatesFromPayload(payload: unknown): MarketChannelUpdate[] {
+  const records = deepCollectRecords(payload);
+  const byMarketId = new Map<string, MarketChannelUpdate>();
+
+  for (const record of records) {
+    const primaryId = pickFirstString(record, MARKET_ID_PRIMARY_KEYS);
+    const fallbackId = pickFirstString(record, MARKET_ID_FALLBACK_KEYS);
+    const marketId = primaryId ?? fallbackId;
+    if (!marketId) {
+      continue;
+    }
+
+    const lastTradePrice = pickFirstNumber(record, LAST_TRADE_PRICE_KEYS);
+    const bestBid = pickFirstNumber(record, BEST_BID_KEYS);
+    const bestAsk = pickFirstNumber(record, BEST_ASK_KEYS);
+    const hasPriceSignal = lastTradePrice !== null || bestBid !== null || bestAsk !== null;
+
+    // `id` is too generic, so only trust fallback ids when price fields are present.
+    if (!primaryId && !hasPriceSignal) {
+      continue;
+    }
+
+    byMarketId.set(marketId, {
+      marketId,
+      lastTradePrice,
+      bestBid,
+      bestAsk,
+    });
+  }
+
+  return [...byMarketId.values()];
+}
+
+export class SmartFirehoseClient {
+  private readonly websocketUrl: string;
+  private readonly subscriptionMessage: Record<string, unknown> | null;
+  private readonly snapshotMaxStalenessMs: number;
+  private readonly reconnectBaseMs: number;
+  private readonly reconnectMaxMs: number;
+  private readonly connectImpl: WebSocketFactory;
+  private readonly now: () => number;
+  private readonly logger: SmartFirehoseLogger;
+
+  private readonly marketsById = new Map<string, RawPolymarketMarket>();
+  private readonly stats: FirehoseStats = {
+    messages: 0,
+    parseFailures: 0,
+    updatesApplied: 0,
+    unknownMarketUpdates: 0,
+    reconnects: 0,
+    restBootstraps: 0,
+    restFallbacks: 0,
+  };
+
+  private socket: WebSocketLike | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempts = 0;
+  private started = false;
+  private wsConnected = false;
+  private updatedAtMs = 0;
+  private source: "none" | "rest_bootstrap" | "websocket" = "none";
+
+  private readonly onSocketOpen = (): void => {
+    this.wsConnected = true;
+    this.reconnectAttempts = 0;
+    this.logger.info("ingest.firehose.connected", { websocketUrl: this.websocketUrl });
+
+    if (!this.subscriptionMessage || !this.socket) {
+      return;
+    }
+
+    try {
+      this.socket.send(JSON.stringify(this.subscriptionMessage));
+      this.logger.info("ingest.firehose.subscribed", {
+        websocketUrl: this.websocketUrl,
+        mode: "manual_subscription",
+      });
+    } catch (error) {
+      this.logger.warn("ingest.firehose.subscribe_failed", {
+        websocketUrl: this.websocketUrl,
+        detail: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  private readonly onSocketMessage = (event: unknown): void => {
+    this.stats.messages += 1;
+    const text = messageEventToText(event);
+    if (!text) {
+      return;
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      this.stats.parseFailures += 1;
+      return;
+    }
+
+    const updates = extractMarketUpdatesFromPayload(payload);
+    if (updates.length === 0) {
+      return;
+    }
+
+    let applied = 0;
+    for (const update of updates) {
+      if (this.applyMarketUpdate(update)) {
+        applied += 1;
+      }
+    }
+
+    if (applied > 0) {
+      this.markUpdated("websocket");
+    }
+  };
+
+  private readonly onSocketClose = (): void => {
+    this.wsConnected = false;
+    this.detachSocketListeners();
+    if (this.started) {
+      this.scheduleReconnect("close");
+    }
+  };
+
+  private readonly onSocketError = (): void => {
+    this.wsConnected = false;
+    if (this.started) {
+      this.scheduleReconnect("error");
+    }
+  };
+
+  constructor(options: SmartFirehoseOptions = {}) {
+    this.websocketUrl = options.websocketUrl ?? DEFAULT_POLYMARKET_MARKET_WS_URL;
+    this.subscriptionMessage = options.subscriptionMessage ?? null;
+    this.snapshotMaxStalenessMs = options.snapshotMaxStalenessMs ?? DEFAULT_SNAPSHOT_MAX_STALENESS_MS;
+    this.reconnectBaseMs = options.reconnectBaseMs ?? DEFAULT_RECONNECT_BASE_MS;
+    this.reconnectMaxMs = options.reconnectMaxMs ?? DEFAULT_RECONNECT_MAX_MS;
+    this.connectImpl = options.connectImpl ?? defaultWebSocketFactory;
+    this.now = options.now ?? (() => Date.now());
+    this.logger = options.logger ?? { info: logInfo, warn: logWarn };
+  }
+
+  start(): void {
+    if (this.started) {
+      return;
+    }
+    this.started = true;
+    this.openSocket();
+  }
+
+  stop(): void {
+    this.started = false;
+    this.wsConnected = false;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.socket) {
+      try {
+        this.socket.close(1000, "smart firehose stopped");
+      } catch {
+        // Best effort close.
+      }
+    }
+    this.detachSocketListeners();
+  }
+
+  async bootstrap(fetchOptions: PolymarketFetchOptions = {}): Promise<ActiveMarketsFetchResult> {
+    const fetched = await fetchActiveMarkets(fetchOptions);
+    this.replaceSnapshot(fetched.markets, "rest_bootstrap");
+    this.stats.restBootstraps += 1;
+    return fetched;
+  }
+
+  getSnapshot(maxStalenessMs = this.snapshotMaxStalenessMs): FirehoseSnapshot {
+    const ageMs = this.updatedAtMs > 0 ? Math.max(0, this.now() - this.updatedAtMs) : Number.POSITIVE_INFINITY;
+    const isFresh = this.marketsById.size > 0 && ageMs <= Math.max(1, maxStalenessMs);
+    return {
+      source: this.source,
+      updatedAt: this.updatedAtMs > 0 ? toIsoDate(this.updatedAtMs) : null,
+      updatedAtMs: this.updatedAtMs,
+      marketCount: this.marketsById.size,
+      isFresh,
+      wsConnected: this.wsConnected,
+      markets: [...this.marketsById.values()],
+      stats: { ...this.stats },
+    };
+  }
+
+  async fetchForIngestion(
+    fetchOptions: PolymarketFetchOptions = {},
+    maxStalenessMs = this.snapshotMaxStalenessMs
+  ): Promise<FirehoseFetchResult> {
+    const snapshot = this.getSnapshot(maxStalenessMs);
+    if (snapshot.isFresh) {
+      return {
+        markets: snapshot.markets,
+        pagesFetched: 0,
+        source: "firehose_snapshot",
+      };
+    }
+
+    const fallback = await this.bootstrap(fetchOptions);
+    this.stats.restFallbacks += 1;
+    return {
+      ...fallback,
+      source: "rest_fallback",
+    };
+  }
+
+  private openSocket(): void {
+    if (!this.started || this.socket) {
+      return;
+    }
+
+    try {
+      this.socket = this.connectImpl(this.websocketUrl);
+      this.socket.addEventListener("open", this.onSocketOpen);
+      this.socket.addEventListener("message", this.onSocketMessage);
+      this.socket.addEventListener("close", this.onSocketClose);
+      this.socket.addEventListener("error", this.onSocketError);
+    } catch (error) {
+      this.scheduleReconnect("connect_error", error);
+    }
+  }
+
+  private detachSocketListeners(): void {
+    if (!this.socket) {
+      return;
+    }
+    this.socket.removeEventListener("open", this.onSocketOpen);
+    this.socket.removeEventListener("message", this.onSocketMessage);
+    this.socket.removeEventListener("close", this.onSocketClose);
+    this.socket.removeEventListener("error", this.onSocketError);
+    this.socket = null;
+  }
+
+  private scheduleReconnect(reason: string, error?: unknown): void {
+    if (!this.started || this.reconnectTimer) {
+      return;
+    }
+
+    this.detachSocketListeners();
+    this.reconnectAttempts += 1;
+    this.stats.reconnects += 1;
+    const delayMs = computeReconnectDelay(this.reconnectAttempts, this.reconnectBaseMs, this.reconnectMaxMs);
+    this.logger.warn("ingest.firehose.reconnect_scheduled", {
+      reason,
+      attempt: this.reconnectAttempts,
+      delayMs,
+      detail: error instanceof Error ? error.message : error ? String(error) : null,
+    });
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.openSocket();
+    }, delayMs);
+  }
+
+  private replaceSnapshot(markets: RawPolymarketMarket[], source: "rest_bootstrap" | "websocket"): void {
+    this.marketsById.clear();
+    for (const market of markets) {
+      const id = asStringId(market.id ?? market.marketId);
+      if (!id) {
+        continue;
+      }
+      this.marketsById.set(id, {
+        ...market,
+        id: market.id ?? id,
+      });
+    }
+    this.markUpdated(source);
+  }
+
+  private markUpdated(source: "rest_bootstrap" | "websocket"): void {
+    this.source = source;
+    this.updatedAtMs = this.now();
+  }
+
+  private applyMarketUpdate(update: MarketChannelUpdate): boolean {
+    const current = this.marketsById.get(update.marketId);
+    if (!current) {
+      this.stats.unknownMarketUpdates += 1;
+      return false;
+    }
+
+    const next: RawPolymarketMarket = {
+      ...current,
+      updatedAt: toIsoDate(this.now()),
+    };
+
+    if (update.lastTradePrice !== null) {
+      next.lastTradePrice = update.lastTradePrice;
+      next.price = update.lastTradePrice;
+    }
+    if (update.bestBid !== null) {
+      next.bestBid = update.bestBid;
+    }
+    if (update.bestAsk !== null) {
+      next.bestAsk = update.bestAsk;
+    }
+
+    this.marketsById.set(update.marketId, next);
+    this.stats.updatesApplied += 1;
+    return true;
+  }
+}

--- a/services/ingest-worker/src/smoke.ts
+++ b/services/ingest-worker/src/smoke.ts
@@ -1,5 +1,10 @@
 import { runAndPersistIngestion, runIngestionOnce } from "./index.js";
-import { logError, logInfo } from "./logger.js";
+import {
+  DEFAULT_POLYMARKET_MARKET_WS_URL,
+  SmartFirehoseClient,
+  type SmartFirehoseLogger,
+} from "./polymarket-firehose.js";
+import { logError, logInfo, logWarn } from "./logger.js";
 
 function parseEnvInt(name: string, fallback: number): number {
   const value = process.env[name];
@@ -10,11 +15,49 @@ function parseEnvInt(name: string, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function parseEnvBool(name: string, fallback: boolean): boolean {
+  const value = process.env[name];
+  if (!value) {
+    return fallback;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "1" || normalized === "true" || normalized === "yes") {
+    return true;
+  }
+  if (normalized === "0" || normalized === "false" || normalized === "no") {
+    return false;
+  }
+  return fallback;
+}
+
+function parseEnvJsonObject(name: string): Record<string, unknown> | null {
+  const value = process.env[name];
+  if (!value || !value.trim()) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 async function main(): Promise<void> {
   const limitPerPage = parseEnvInt("POLYMARKET_LIMIT_PER_PAGE", 50);
   const maxPages = parseEnvInt("POLYMARKET_MAX_PAGES", 2);
   const retries = parseEnvInt("POLYMARKET_RETRIES", 2);
   const requestTimeoutMs = parseEnvInt("POLYMARKET_TIMEOUT_MS", 12000);
+  const useSmartFirehose = parseEnvBool("INGEST_USE_SMART_FIREHOSE", false);
+  const firehoseMaxStalenessMs = parseEnvInt("INGEST_FIREHOSE_STALENESS_MS", 90_000);
+  const firehoseReconnectBaseMs = parseEnvInt("INGEST_FIREHOSE_RECONNECT_BASE_MS", 800);
+  const firehoseReconnectMaxMs = parseEnvInt("INGEST_FIREHOSE_RECONNECT_MAX_MS", 15_000);
+  const firehoseWarmupMs = parseEnvInt("INGEST_FIREHOSE_WARMUP_MS", 4_000);
+  const firehoseWsUrl = process.env.INGEST_FIREHOSE_WS_URL || DEFAULT_POLYMARKET_MARKET_WS_URL;
+  const firehoseSubscription = parseEnvJsonObject("INGEST_FIREHOSE_SUBSCRIPTION_JSON");
   const outputDir = process.env.INGEST_OUTPUT_DIR;
   const dbPath = process.env.INGEST_SQLITE_DB_PATH;
   const shouldPersist = process.env.INGEST_PERSIST !== "0";
@@ -33,53 +76,95 @@ async function main(): Promise<void> {
     maxPages,
     retries,
     requestTimeoutMs,
+    useSmartFirehose,
+    firehoseMaxStalenessMs,
+    firehoseWarmupMs,
     shouldPersist,
     persistJson,
     persistSqlite,
   });
 
-  const result = shouldPersist
-    ? await runAndPersistIngestion(fetchOptions, { outputDir, dbPath, persistJson, persistSqlite })
-    : await runIngestionOnce(fetchOptions);
+  const firehoseLogger: SmartFirehoseLogger = {
+    info: (event, details = {}) => logInfo(event, details),
+    warn: (event, details = {}) => logWarn(event, details),
+  };
 
-  const preview = result.normalizedMarkets.slice(0, 5).map((market, index) => ({
-    rank: index + 1,
-    id: market.id,
-    question: market.question,
-    endDate: market.endDate,
-    volume: market.volume,
-    liquidity: market.liquidity,
-  }));
+  const firehoseClient = useSmartFirehose
+    ? new SmartFirehoseClient({
+        websocketUrl: firehoseWsUrl,
+        subscriptionMessage: firehoseSubscription,
+        snapshotMaxStalenessMs: firehoseMaxStalenessMs,
+        reconnectBaseMs: firehoseReconnectBaseMs,
+        reconnectMaxMs: firehoseReconnectMaxMs,
+        logger: firehoseLogger,
+      })
+    : null;
 
-  // Keep output concise and machine-readable for CI or manual local checks.
-  console.log(
-    JSON.stringify(
-      {
-        smoke: "ok",
-        snapshot: result.snapshot,
-        metrics: result.metrics,
-        persisted: {
-          json: result.persistedJson ?? null,
-          sqlite: result.persistedSqlite ?? null,
+  try {
+    if (firehoseClient) {
+      firehoseClient.start();
+      if (firehoseWarmupMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, firehoseWarmupMs));
+      }
+    }
+
+    const runOptions = firehoseClient
+      ? {
+          ...fetchOptions,
+          firehoseClient,
+          firehoseMaxStalenessMs,
+        }
+      : fetchOptions;
+
+    const result = shouldPersist
+      ? await runAndPersistIngestion(runOptions, { outputDir, dbPath, persistJson, persistSqlite })
+      : await runIngestionOnce(runOptions);
+
+    const preview = result.normalizedMarkets.slice(0, 5).map((market, index) => ({
+      rank: index + 1,
+      id: market.id,
+      question: market.question,
+      endDate: market.endDate,
+      volume: market.volume,
+      liquidity: market.liquidity,
+    }));
+
+    // Keep output concise and machine-readable for CI or manual local checks.
+    console.log(
+      JSON.stringify(
+        {
+          smoke: "ok",
+          snapshot: result.snapshot,
+          metrics: result.metrics,
+          firehose: firehoseClient ? firehoseClient.getSnapshot(firehoseMaxStalenessMs) : null,
+          persisted: {
+            json: result.persistedJson ?? null,
+            sqlite: result.persistedSqlite ?? null,
+          },
+          preview,
         },
-        preview,
-      },
-      null,
-      2
-    )
-  );
+        null,
+        2
+      )
+    );
 
-  logInfo("ingest.smoke.success", {
-    runId: result.persistedJson?.runId ?? result.persistedSqlite?.runId ?? "n/a",
-    rawCount: result.snapshot.rawCount,
-    normalizedCount: result.snapshot.normalizedCount,
-    droppedCount: result.snapshot.droppedCount,
-    fetchMs: result.metrics.fetchMs,
-    normalizeMs: result.metrics.normalizeMs,
-    persistJsonMs: result.metrics.persistJsonMs,
-    persistSqliteMs: result.metrics.persistSqliteMs,
-    totalMs: result.metrics.totalMs,
-  });
+    logInfo("ingest.smoke.success", {
+      runId: result.persistedJson?.runId ?? result.persistedSqlite?.runId ?? "n/a",
+      source: result.snapshot.source,
+      rawCount: result.snapshot.rawCount,
+      normalizedCount: result.snapshot.normalizedCount,
+      droppedCount: result.snapshot.droppedCount,
+      fetchMs: result.metrics.fetchMs,
+      normalizeMs: result.metrics.normalizeMs,
+      persistJsonMs: result.metrics.persistJsonMs,
+      persistSqliteMs: result.metrics.persistSqliteMs,
+      totalMs: result.metrics.totalMs,
+    });
+  } finally {
+    if (firehoseClient) {
+      firehoseClient.stop();
+    }
+  }
 }
 
 main().catch((error) => {

--- a/services/ingest-worker/src/sqlite-storage.test.ts
+++ b/services/ingest-worker/src/sqlite-storage.test.ts
@@ -34,6 +34,7 @@ describe("sqlite persistence", () => {
           rawCount: 2,
           normalizedCount: 1,
           droppedCount: 1,
+          source: "rest_fallback",
         },
         rawMarkets: [
           { id: "raw-1", question: "raw q1" },

--- a/services/ingest-worker/src/storage.test.ts
+++ b/services/ingest-worker/src/storage.test.ts
@@ -28,6 +28,7 @@ describe("persistIngestionRun", () => {
           rawCount: 3,
           normalizedCount: 2,
           droppedCount: 1,
+          source: "rest_fallback",
         },
         rawMarkets: [{ id: "raw-1", question: "Raw Q1" }],
         normalizedMarkets: [
@@ -62,4 +63,3 @@ describe("persistIngestionRun", () => {
     expect(parsedNormalized[0]?.id).toBe("norm-1");
   });
 });
-


### PR DESCRIPTION
## Summary
- add SmartFirehoseClient foundation in ingest worker with:
  - Polymarket market-channel websocket connection
  - reconnect/backoff handling
  - in-memory snapshot freshness checks
  - automatic REST fallback when snapshot is stale/missing
- wire ingestion runner to optionally use firehose snapshot source (irehose_snapshot vs est_fallback)
- add smoke-runner env toggles for firehose mode and expose snapshot diagnostics
- add full test coverage for parsing, snapshot usage, fallback, websocket updates, and reconnect behavior
- update roadmap/progress docs for milestone tracking

## Validation
- 
pm -C services/ingest-worker run typecheck
- 
pm -C services/ingest-worker run lint
- 
pm -C services/ingest-worker run test
- 
pm run check
