### PR TITLE
docs: add dated launch-readiness review and decision log

### DIFF
--- a/docs/EDITORIAL_REVIEW_LOG.md
+++ b/docs/EDITORIAL_REVIEW_LOG.md
@@ -13,4 +13,5 @@ Append one row per review pass.
 
 | Reviewed At (UTC) | Reviewer | Snapshot Run ID | Environment | Decision | Notes |
 |---|---|---:|---|---|---|
-| 2026-02-21T00:00:00Z | <name> | 00000000000 | production/staging | pass or follow-up | summary + actions |
+| 2026-02-28T19:27:21Z | AhmadTahmid + Codex | 22527421938 | production | pass | Top-20 composition: politics 13 (0.65), geopolitics 5 (0.25), economy 1 (0.05), sports 1 (0.05). No obvious meme/noise leakage in sampled cards. |
+| 2026-02-28T19:27:21Z | AhmadTahmid + Codex | 22527421938 | staging | pass | Top-20 composition: politics 13 (0.65), geopolitics 4 (0.20), economy 2 (0.10), sports 1 (0.05). Ordering and links/odds checks looked consistent with production intent. |

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -942,3 +942,25 @@
      - `attempted=true`
      - `connected=true`
    - monitor workflow: `Monitor Staging` run `22525950039` => success.
+314. Ran fresh editorial snapshot workflow for launch-readiness evidence:
+   - workflow: `Editorial Spotcheck`
+   - run: `22527421938`
+   - result: success
+   - artifact: `editorial-spotcheck-22527421938` (includes `editorial-spotcheck.json` and `.md`).
+315. Recorded reviewer log entries in `docs/EDITORIAL_REVIEW_LOG.md` using run `22527421938`:
+   - production review marked `pass`
+   - staging review marked `pass`
+   - sampled top-20 composition remained within current category-cap policy (`politics` share `0.65`).
+316. Executed launch-stability script locally for strict 24h gate status:
+   - command: `node scripts/launch-stability.mjs`
+   - generated at: `2026-02-28T19:20:44.604Z`
+   - result: `overallReady=false`
+   - key reasons:
+     - production: historical failures/gaps in current 24h window (`runs=49`, `failures=5`, `maxGap=126.17m`)
+     - staging: historical gap threshold miss (`runs=48`, `failures=0`, `maxGap=135.3m`).
+317. Launch decision entry (dated):
+   - decision time: `2026-02-28T19:30:00Z`
+   - decision: `SOFT-GO (beta operation)` with explicit exception; not a strict public launch pass yet.
+   - owner: `AhmadTahmid`
+   - exception expiry: `2026-03-01T19:30:00Z`
+   - condition to clear exception: next clean 24h `Launch Stability` window with `overallReady=true`.


### PR DESCRIPTION
## Summary
- add real editorial review entries to docs/EDITORIAL_REVIEW_LOG.md using latest snapshot run 22527421938
- append launch-readiness evidence and dated decision entry to docs/PROGRESS_LOG.md
- record strict 24h launch-stability status and explicit exception window details

## Evidence captured
- Editorial Spotcheck run: 22527421938 (success)
- Launch Stability script output (local): overallReady=false at 2026-02-28T19:20:44.604Z with historical gap/failure reasons

## Scope
- docs only, no runtime/infrastructure changes